### PR TITLE
InitMangoAccount: removed rent sysvar account

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -49,7 +49,7 @@ pub enum MangoInstruction {
 
     /// Deposit funds into mango account
     ///
-    /// Accounts expected by this instruction (8):
+    /// Accounts expected by this instruction (9):
     ///
     /// 0. `[]` mango_group_ai - MangoGroup that this mango account is for
     /// 1. `[writable]` mango_account_ai - the mango account for this user
@@ -66,20 +66,19 @@ pub enum MangoInstruction {
 
     /// Withdraw funds that were deposited earlier.
     ///
-    /// Accounts expected by this instruction (10):
+    /// Accounts expected by this instruction (10+MAX_PAIRS):
     ///
-    /// 0. `[read]` mango_group_ai,   -
-    /// 1. `[write]` mango_account_ai, -
-    /// 2. `[read]` owner_ai,         -
-    /// 3. `[read]` mango_cache_ai,   -
-    /// 4. `[read]` root_bank_ai,     -
-    /// 5. `[write]` node_bank_ai,     -
-    /// 6. `[write]` vault_ai,         -
-    /// 7. `[write]` token_account_ai, -
-    /// 8. `[read]` signer_ai,        -
-    /// 9. `[read]` token_prog_ai,    -
-    /// 10. `[read]` clock_ai,         -
-    /// 11..+ `[]` open_orders_accs - open orders for each of the spot market
+    /// 0. `[writable]` mango_group_ai,   -
+    /// 1. `[writable]` mango_account_ai, -
+    /// 2. `[signer]` owner_ai,         -
+    /// 3. `[]` mango_cache_ai,   -
+    /// 4. `[]` root_bank_ai,     -
+    /// 5. `[writable]` node_bank_ai,     -
+    /// 6. `[writable]` vault_ai,         -
+    /// 7. `[writable]` token_account_ai, -
+    /// 8. `[]` signer_ai,        -
+    /// 9. `[]` token_prog_ai,    -
+    /// 10..+ `[]` open_orders_accs - open orders for each of the spot market
     Withdraw {
         quantity: u64,
         allow_borrow: bool,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -45,7 +45,6 @@ pub enum MangoInstruction {
     /// 0. `[]` mango_group_ai - MangoGroup that this mango account is for
     /// 1. `[writable]` mango_account_ai - the mango account data
     /// 2. `[signer]` owner_ai - Solana account of owner of the mango account
-    /// 3. `[]` rent_ai - Rent sysvar account
     InitMangoAccount,
 
     /// Deposit funds into mango account
@@ -1001,7 +1000,6 @@ pub fn init_mango_account(
         AccountMeta::new_readonly(*mango_group_pk, false),
         AccountMeta::new(*mango_account_pk, false),
         AccountMeta::new_readonly(*owner_pk, true),
-        AccountMeta::new_readonly(solana_program::sysvar::rent::ID, false),
     ];
 
     let instr = MangoInstruction::InitMangoAccount;

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -40,7 +40,7 @@ pub enum MangoInstruction {
 
     /// Initialize a mango account for a user
     ///
-    /// Accounts expected by this instruction (4):
+    /// Accounts expected by this instruction (3):
     ///
     /// 0. `[]` mango_group_ai - MangoGroup that this mango account is for
     /// 1. `[writable]` mango_account_ai - the mango account data

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -780,7 +780,7 @@ impl Processor {
         let accounts = array_ref![accounts, 0, NUM_FIXED + MAX_PAIRS];
         let (fixed_ais, open_orders_ais) = array_refs![accounts, NUM_FIXED, MAX_PAIRS];
         let [
-            mango_group_ai,     // read
+            mango_group_ai,     // write
             mango_account_ai,   // write
             owner_ai,           // read
             mango_cache_ai,     // read


### PR DESCRIPTION
The rent sysvar account is not required for the mango account
initialization in the instructions; processors.rs does not use it.