### PR TITLE
Fix test build: don't require &'a [AccountInfo<'a>] lifetimes

### DIFF
--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -4,9 +4,9 @@ use solana_program::{
 };
 
 entrypoint!(process_instruction);
-pub fn process_instruction<'a>(
+pub fn process_instruction(
     program_id: &Pubkey,
-    accounts: &'a [AccountInfo<'a>],
+    accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
     Processor::process(program_id, accounts, instruction_data).map_err(|e| {

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1170,9 +1170,9 @@ impl Processor {
     }
 
     #[inline(never)]
-    fn place_spot_order2<'a>(
+    fn place_spot_order2(
         program_id: &Pubkey,
-        accounts: &'a [AccountInfo<'a>],
+        accounts: &[AccountInfo],
         order: serum_dex::instruction::NewOrderInstructionV3,
     ) -> MangoResult<()> {
         const NUM_FIXED: usize = 22;
@@ -3930,9 +3930,9 @@ impl Processor {
     /// The TriggerCondition specifies if trigger_price  must be above or below oracle price
     /// When the condition is met, the order is executed as a regular perp order
     #[inline(never)]
-    fn add_perp_trigger_order<'a>(
+    fn add_perp_trigger_order(
         program_id: &Pubkey,
-        accounts: &'a [AccountInfo<'a>],
+        accounts: &[AccountInfo],
         order_type: OrderType,
         side: Side,
         trigger_condition: TriggerCondition,
@@ -4081,9 +4081,9 @@ impl Processor {
     }
 
     #[inline(never)]
-    fn execute_perp_trigger_order<'a>(
+    fn execute_perp_trigger_order(
         program_id: &Pubkey,
-        accounts: &'a [AccountInfo<'a>],
+        accounts: &[AccountInfo],
         order_index: u8,
     ) -> MangoResult<()> {
         let order_index = order_index as usize;
@@ -4286,9 +4286,9 @@ impl Processor {
         program_transfer_lamports(advanced_orders_ai, agent_ai, ADVANCED_ORDER_FEE)
     }
 
-    pub fn process<'a>(
+    pub fn process(
         program_id: &Pubkey,
-        accounts: &'a [AccountInfo<'a>],
+        accounts: &[AccountInfo],
         data: &[u8],
     ) -> MangoResult<()> {
         let instruction =

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -1333,11 +1333,11 @@ impl MangoAccount {
         true
     }
 
-    pub fn checked_unpack_open_orders<'a>(
+    pub fn checked_unpack_open_orders<'a, 'b>(
         &self,
         mango_group: &MangoGroup,
-        open_orders_ais: &'a [AccountInfo<'a>],
-    ) -> MangoResult<Vec<Option<&'a AccountInfo<'a>>>> {
+        open_orders_ais: &'a [AccountInfo<'b>],
+    ) -> MangoResult<Vec<Option<&'a AccountInfo<'b>>>> {
         let mut unpacked = vec![None; MAX_PAIRS];
         for i in 0..mango_group.num_oracles {
             if self.in_margin_basket[i] {


### PR DESCRIPTION
It's sufficient to propagate the lifetimes on `checked_unpack_open_orders`.