### PR TITLE
Add perp trigger order unittest

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1404,6 +1404,117 @@ pub fn force_cancel_perp_orders(
     Ok(Instruction { program_id: *program_id, accounts, data })
 }
 
+pub fn init_advanced_orders(
+    program_id: &Pubkey,
+    mango_group_pk: &Pubkey,         // read
+    mango_account_pk: &Pubkey,       // write
+    owner_pk: &Pubkey,               // write & signer
+    advanced_orders_pk: &Pubkey,     // write
+    system_prog_pk: &Pubkey,         // read
+) -> Result<Instruction, ProgramError> {
+    let mut accounts = vec![
+        AccountMeta::new_readonly(*mango_group_pk, false),
+        AccountMeta::new(*mango_account_pk, false),
+        AccountMeta::new(*owner_pk, true),
+        AccountMeta::new(*advanced_orders_pk, false),
+        AccountMeta::new_readonly(*system_prog_pk, false),
+    ];
+    let instr = MangoInstruction::InitAdvancedOrders { };
+    let data = instr.pack();
+    Ok(Instruction { program_id: *program_id, accounts, data })
+}
+
+pub fn add_perp_trigger_order(
+    program_id: &Pubkey,
+    mango_group_pk: &Pubkey,         // read
+    mango_account_pk: &Pubkey,       // read
+    owner_pk: &Pubkey,               // write & signer
+    advanced_orders_pk: &Pubkey,     // write
+    mango_cache_pk: &Pubkey,         // read
+    perp_market_pk: &Pubkey,         // read
+    system_prog_pk: &Pubkey,         // read
+    order_type: OrderType,
+    side: Side,
+    trigger_condition: TriggerCondition,
+    reduce_only: bool,
+    client_order_id: u64,
+    price: i64,
+    quantity: i64,
+    trigger_price: I80F48,
+) -> Result<Instruction, ProgramError> {
+    let mut accounts = vec![
+        AccountMeta::new_readonly(*mango_group_pk, false),
+        AccountMeta::new_readonly(*mango_account_pk, false),
+        AccountMeta::new(*owner_pk, true),
+        AccountMeta::new(*advanced_orders_pk, false),
+        AccountMeta::new_readonly(*mango_cache_pk, false),
+        AccountMeta::new_readonly(*perp_market_pk, false),
+        AccountMeta::new_readonly(*system_prog_pk, false),
+    ];
+    let instr = MangoInstruction::AddPerpTriggerOrder {
+        order_type,
+        side,
+        trigger_condition,
+        reduce_only,
+        client_order_id,
+        price,
+        quantity,
+        trigger_price,
+    };
+    let data = instr.pack();
+    Ok(Instruction { program_id: *program_id, accounts, data })
+}
+
+pub fn remove_advanced_order(
+    program_id: &Pubkey,
+    mango_group_pk: &Pubkey,         // read
+    mango_account_pk: &Pubkey,       // read
+    owner_pk: &Pubkey,               // write & signer
+    advanced_orders_pk: &Pubkey,     // write
+    system_prog_pk: &Pubkey,         // read
+    order_index: u8,
+) -> Result<Instruction, ProgramError> {
+    let mut accounts = vec![
+        AccountMeta::new_readonly(*mango_group_pk, false),
+        AccountMeta::new_readonly(*mango_account_pk, false),
+        AccountMeta::new(*owner_pk, true),
+        AccountMeta::new(*advanced_orders_pk, false),
+        AccountMeta::new_readonly(*system_prog_pk, false),
+    ];
+    let instr = MangoInstruction::RemoveAdvancedOrder { order_index };
+    let data = instr.pack();
+    Ok(Instruction { program_id: *program_id, accounts, data })
+}
+
+pub fn execute_perp_trigger_order(
+    program_id: &Pubkey,
+    mango_group_pk: &Pubkey,         // read
+    mango_account_pk: &Pubkey,       // write
+    advanced_orders_pk: &Pubkey,     // write
+    agent_pk: &Pubkey,               // write & signer
+    mango_cache_pk: &Pubkey,         // read
+    perp_market_pk: &Pubkey,         // write
+    bids_pk: &Pubkey,                // write
+    asks_pk: &Pubkey,                // write
+    event_queue_pk: &Pubkey,         // write
+    order_index: u8,
+) -> Result<Instruction, ProgramError> {
+    let mut accounts = vec![
+        AccountMeta::new_readonly(*mango_group_pk, false),
+        AccountMeta::new(*mango_account_pk, false),
+        AccountMeta::new(*advanced_orders_pk, false),
+        AccountMeta::new(*agent_pk, true),
+        AccountMeta::new_readonly(*mango_cache_pk, false),
+        AccountMeta::new(*perp_market_pk, false),
+        AccountMeta::new(*bids_pk, false),
+        AccountMeta::new(*asks_pk, false),
+        AccountMeta::new(*event_queue_pk, false),
+    ];
+    let instr = MangoInstruction::ExecutePerpTriggerOrder{ order_index };
+    let data = instr.pack();
+    Ok(Instruction { program_id: *program_id, accounts, data })
+}
+
 pub fn consume_events(
     program_id: &Pubkey,
     mango_group_pk: &Pubkey,      // read

--- a/program/src/matching.rs
+++ b/program/src/matching.rs
@@ -662,7 +662,12 @@ impl<'a> Book<'a> {
         let mut rem_quantity = quantity; // base lots (aka contracts)
         let mut stack = vec![];
         let mut current = match self.asks.root() {
-            None => return Ok((taker_base, taker_quote, bids_quantity, asks_quantity)),
+            None => {
+                if rem_quantity > 0 && post_allowed {
+                    bids_quantity += rem_quantity;
+                }
+                return Ok((taker_base, taker_quote, bids_quantity, asks_quantity));
+            },
             Some(node_handle) => node_handle,
         };
         while rem_quantity > 0 {
@@ -730,7 +735,12 @@ impl<'a> Book<'a> {
         let mut rem_quantity = quantity; // base lots (aka contracts)
         let mut stack = vec![];
         let mut current = match self.bids.root() {
-            None => return Ok((taker_base, taker_quote, bids_quantity, asks_quantity)),
+            None => {
+                if rem_quantity > 0 && post_allowed {
+                    asks_quantity += rem_quantity;
+                }
+                return Ok((taker_base, taker_quote, bids_quantity, asks_quantity));
+            },
             Some(node_handle) => node_handle,
         };
         while rem_quantity > 0 {

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -4113,7 +4113,7 @@ impl Processor {
         let (fixed_ais, open_orders_ais) = array_refs![accounts, NUM_FIXED; ..;];
         let [
             mango_group_ai,         // read
-            mango_account_ai,       // read
+            mango_account_ai,       // write
             advanced_orders_ai,     // write
             agent_ai,               // write
             mango_cache_ai,         // read

--- a/program/tests/program_test/assertions.rs
+++ b/program/tests/program_test/assertions.rs
@@ -230,9 +230,9 @@ pub async fn assert_vault_net_deposit_diff(
     total_net = total_net.checked_round().unwrap();
 
     let mut vault_amount = ZERO_I80F48;
-    for node_bank_pk in root_bank.node_banks {
-      if node_bank_pk != Pubkey::default() {
-          let node_bank = test.load_account::<NodeBank>(node_bank_pk).await;
+    for node_bank_pk in root_bank.node_banks.iter() {
+      if *node_bank_pk != Pubkey::default() {
+          let node_bank = test.load_account::<NodeBank>(*node_bank_pk).await;
           let balance = test.get_token_balance(node_bank.vault).await;
           vault_amount += I80F48::from_num(balance);
       }

--- a/program/tests/program_test/cookies.rs
+++ b/program/tests/program_test/cookies.rs
@@ -4,6 +4,7 @@ use std::num::NonZeroU64;
 
 use solana_program::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signer};
+use solana_sdk::transport::TransportError;
 
 use mango::{ids::*, matching::*, queue::*, state::*, utils::*};
 
@@ -11,6 +12,7 @@ use crate::*;
 
 pub const STARTING_SPOT_ORDER_ID: u64 = 0;
 pub const STARTING_PERP_ORDER_ID: u64 = 10_000;
+pub const STARTING_ADVANCED_ORDER_ID: u64 = 20_000;
 
 #[derive(Copy, Clone)]
 pub struct MintCookie {
@@ -39,6 +41,8 @@ pub struct MangoGroupCookie {
     pub current_spot_order_id: u64,
 
     pub current_perp_order_id: u64,
+
+    pub current_advanced_order_id: u64,
 
     pub users_with_spot_event: Vec<Vec<usize>>,
 
@@ -107,6 +111,7 @@ impl MangoGroupCookie {
             perp_markets: vec![],
             current_spot_order_id: STARTING_SPOT_ORDER_ID,
             current_perp_order_id: STARTING_PERP_ORDER_ID,
+            current_advanced_order_id: STARTING_ADVANCED_ORDER_ID,
             users_with_spot_event: vec![Vec::new(); test.num_mints - 1],
             users_with_perp_event: vec![Vec::new(); test.num_mints - 1],
         }
@@ -308,6 +313,7 @@ impl MangoGroupCookie {
 
 pub struct MangoAccountCookie {
     pub address: Pubkey,
+    pub user: Keypair,
 
     pub mango_account: MangoAccount,
 }
@@ -334,7 +340,80 @@ impl MangoAccountCookie {
         .unwrap()];
         test.process_transaction(&instructions, Some(&[&user])).await.unwrap();
         let mango_account = test.load_account::<MangoAccount>(mango_account_pk).await;
-        MangoAccountCookie { address: mango_account_pk, mango_account: mango_account }
+        MangoAccountCookie { address: mango_account_pk, user, mango_account }
+    }
+}
+
+pub struct AdvancedOrdersCookie {
+    pub address: Pubkey,
+
+    pub advanced_orders: AdvancedOrders,
+}
+
+impl AdvancedOrdersCookie {
+    #[allow(dead_code)]
+    pub async fn init(
+        test: &mut MangoProgramTest,
+        mango_account_cookie: &MangoAccountCookie,
+    ) -> Self {
+        let mango_program_id = test.mango_program_id;
+        let mango_account = &mango_account_cookie.mango_account;
+        let user = &mango_account_cookie.user;
+        let user_pk = user.pubkey();
+        assert!(user_pk == mango_account.owner);
+
+        let (advanced_orders_pk, _bump_seed) = Pubkey::find_program_address(
+            &[&mango_account_cookie.address.to_bytes()],
+            &mango_program_id,
+        );
+
+        let instructions = [mango::instruction::init_advanced_orders(
+            &mango_program_id,
+            &mango_account.mango_group,
+            &mango_account_cookie.address,
+            &user_pk,
+            &advanced_orders_pk,
+            &solana_sdk::system_program::id(),
+        )
+        .unwrap()];
+        test.process_transaction(&instructions, Some(&[user])).await.unwrap();
+        let advanced_orders = test.load_account::<AdvancedOrders>(advanced_orders_pk).await;
+        AdvancedOrdersCookie { address: advanced_orders_pk, advanced_orders }
+    }
+
+    #[allow(dead_code)]
+    pub async fn remove_advanced_order(
+        &mut self,
+        test: &mut MangoProgramTest,
+        mango_group_cookie: &mut MangoGroupCookie,
+        user_index: usize,
+        order_index: u8,
+    ) -> Result<(), TransportError> {
+        let mango_program_id = test.mango_program_id;
+        let mango_account_cookie = &mango_group_cookie.mango_accounts[user_index];
+        let mango_account_pk = mango_account_cookie.address;
+        let user = &mango_account_cookie.user;
+        let user_pk = user.pubkey();
+        let mango_group_pk = mango_group_cookie.address;
+
+        let instructions = [mango::instruction::remove_advanced_order(
+            &mango_program_id,
+            &mango_group_pk,
+            &mango_account_pk,
+            &user_pk,
+            &self.address,
+            &solana_sdk::system_program::id(),
+            order_index,
+        )
+        .unwrap()];
+
+        let result = test.process_transaction(&instructions, Some(&[&user])).await;
+
+        if result.is_ok() {
+            self.advanced_orders = test.load_account::<AdvancedOrders>(self.address).await;
+        }
+
+        result
     }
 }
 
@@ -564,5 +643,109 @@ impl PerpMarketCookie {
             .load_account::<MangoAccount>(mango_group_cookie.mango_accounts[user_index].address)
             .await;
         mango_group_cookie.current_perp_order_id += 1;
+    }
+
+    #[allow(dead_code)]
+    pub async fn add_trigger_order(
+        &mut self,
+        test: &mut MangoProgramTest,
+        mango_group_cookie: &mut MangoGroupCookie,
+        advanced_orders_cookie: &mut AdvancedOrdersCookie,
+        user_index: usize,
+        order_type: mango::matching::OrderType,
+        side: mango::matching::Side,
+        trigger_condition: TriggerCondition,
+        price: f64,
+        quantity: f64,
+        trigger_price: I80F48,
+    ) {
+        let mango_program_id = test.mango_program_id;
+        let mango_account_cookie = &mango_group_cookie.mango_accounts[user_index];
+        let mango_account_pk = mango_account_cookie.address;
+        let user = &mango_account_cookie.user;
+        let user_pk = user.pubkey();
+        let mango_group = mango_group_cookie.mango_group;
+        let mango_group_pk = mango_group_cookie.address;
+        let perp_market_pk = self.address;
+        let order_quantity = test.base_size_number_to_lots(&self.mint, quantity);
+        let order_price = test.price_number_to_lots(&self.mint, price);
+        let order_id = mango_group_cookie.current_advanced_order_id;
+
+        let instructions = [mango::instruction::add_perp_trigger_order(
+            &mango_program_id,
+            &mango_group_pk,
+            &mango_account_pk,
+            &user_pk,
+            &advanced_orders_cookie.address,
+            &mango_group.mango_cache,
+            &perp_market_pk,
+            &solana_sdk::system_program::id(),
+            order_type,
+            side,
+            trigger_condition,
+            false,
+            order_id,
+            order_price as i64,
+            order_quantity as i64,
+            trigger_price,
+        )
+        .unwrap()];
+
+        test.process_transaction(&instructions, Some(&[&user])).await.unwrap();
+
+        mango_group_cookie.mango_accounts[user_index].mango_account =
+            test.load_account::<MangoAccount>(mango_account_pk).await;
+        mango_group_cookie.current_advanced_order_id += 1;
+
+        advanced_orders_cookie.advanced_orders =
+            test.load_account::<AdvancedOrders>(advanced_orders_cookie.address).await;
+    }
+
+    #[allow(dead_code)]
+    pub async fn execute_trigger_order(
+        &mut self,
+        test: &mut MangoProgramTest,
+        mango_group_cookie: &mut MangoGroupCookie,
+        advanced_orders_cookie: &mut AdvancedOrdersCookie,
+        user_index: usize,
+        agent_user_index: usize,
+        order_index: u8,
+    ) -> Result<(), TransportError> {
+        let mango_program_id = test.mango_program_id;
+        let mango_account_cookie = &mango_group_cookie.mango_accounts[user_index];
+        let mango_account_pk = mango_account_cookie.address;
+        let agent_user =
+            Keypair::from_base58_string(&test.users[agent_user_index].to_base58_string());
+        let agent_user_pk = agent_user.pubkey();
+        let mango_group = mango_group_cookie.mango_group;
+        let mango_group_pk = mango_group_cookie.address;
+        let perp_market = self.perp_market;
+        let perp_market_pk = self.address;
+
+        let instructions = [mango::instruction::execute_perp_trigger_order(
+            &mango_program_id,
+            &mango_group_pk,
+            &mango_account_pk,
+            &advanced_orders_cookie.address,
+            &agent_user_pk,
+            &mango_group.mango_cache,
+            &perp_market_pk,
+            &perp_market.bids,
+            &perp_market.asks,
+            &perp_market.event_queue,
+            order_index,
+        )
+        .unwrap()];
+
+        let result = test.process_transaction(&instructions, Some(&[&agent_user])).await;
+
+        if result.is_ok() {
+            mango_group_cookie.mango_accounts[user_index].mango_account =
+                test.load_account::<MangoAccount>(mango_account_pk).await;
+            advanced_orders_cookie.advanced_orders =
+                test.load_account::<AdvancedOrders>(advanced_orders_cookie.address).await;
+        }
+
+        result
     }
 }

--- a/program/tests/program_test/mod.rs
+++ b/program/tests/program_test/mod.rs
@@ -313,7 +313,11 @@ impl MangoProgramTest {
             let user_key = Keypair::new();
             test.add_account(
                 user_key.pubkey(),
-                solana_sdk::account::Account::new(u32::MAX as u64, 0, &user_key.pubkey()),
+                solana_sdk::account::Account::new(
+                    u32::MAX as u64,
+                    0,
+                    &solana_sdk::system_program::id(),
+                ),
             );
 
             // give every user 10^18 (< 2^60) of every token
@@ -337,8 +341,6 @@ impl MangoProgramTest {
             }
             users.push(user_key);
         }
-
-
 
         let mut context = test.start_with_context().await;
         let rent = context.banks_client.get_rent().await.unwrap();
@@ -379,9 +381,7 @@ impl MangoProgramTest {
 
         transaction.sign(&all_signers, self.context.last_blockhash);
 
-        self.context.banks_client.process_transaction(transaction).await.unwrap();
-
-        Ok(())
+        self.context.banks_client.process_transaction(transaction).await
     }
 
     #[allow(dead_code)]
@@ -1054,7 +1054,7 @@ impl MangoProgramTest {
     ) {
         let mango_program_id = self.mango_program_id;
         let mut root_bank_pks = Vec::new();
-        for token in mango_group.tokens {
+        for token in mango_group.tokens.iter() {
             if token.root_bank != Pubkey::default() {
                 root_bank_pks.push(token.root_bank);
             }

--- a/program/tests/test_perp_trigger_orders.rs
+++ b/program/tests/test_perp_trigger_orders.rs
@@ -1,0 +1,139 @@
+#![cfg(feature = "test-bpf")]
+
+mod program_test;
+use fixed::types::I80F48;
+use mango::matching::{OrderType, Side};
+use mango::state::TriggerCondition;
+use program_test::assertions::*;
+use program_test::cookies::*;
+use program_test::scenarios::*;
+use program_test::*;
+use solana_program_test::*;
+
+#[tokio::test]
+async fn test_init_perp_trigger_orders() {
+    // === Arrange ===
+    let config = MangoProgramTestConfig { compute_limit: 200_000, num_users: 2, num_mints: 2 };
+    let mut test = MangoProgramTest::start_new(&config).await;
+    // Supress some of the logs
+    solana_logger::setup_with_default(
+        "solana_rbpf::vm=info,\
+             solana_runtime::message_processor=debug,\
+             solana_runtime::system_instruction_processor=info,\
+             solana_program_test=info",
+    );
+    // Disable all logs except error
+    // solana_logger::setup_with("error");
+    let mut mango_group_cookie = MangoGroupCookie::default(&mut test).await;
+    mango_group_cookie.full_setup(&mut test, config.num_users, config.num_mints - 1).await;
+
+    // General parameters
+    let user_index: usize = 0;
+    let user2_index: usize = 1;
+    let mint_index: usize = 0;
+    let base_price: f64 = 10_000.0;
+    let base_size: f64 = 1.0;
+
+    // Set oracles
+    mango_group_cookie.set_oracle(&mut test, mint_index, base_price).await;
+
+    // Deposit
+    let user_deposits = vec![
+        (user_index, test.quote_index, base_price * base_size),
+        (user_index, mint_index, base_size),
+        (user2_index, test.quote_index, base_price * base_size),
+        (user2_index, mint_index, base_size),
+    ];
+    deposit_scenario(&mut test, &mut mango_group_cookie, &user_deposits).await;
+
+    // Make an advanced orders account
+    let mango_account_cookie = &mango_group_cookie.mango_accounts[user_index];
+    let mut advanced_orders_cookie =
+        AdvancedOrdersCookie::init(&mut test, mango_account_cookie).await;
+    assert!(!advanced_orders_cookie.advanced_orders.orders[0].is_active);
+    assert!(!advanced_orders_cookie.advanced_orders.orders[1].is_active);
+
+    // Add two advanced orders
+    let mut perp_market = mango_group_cookie.perp_markets[0];
+    perp_market
+        .add_trigger_order(
+            &mut test,
+            &mut mango_group_cookie,
+            &mut advanced_orders_cookie,
+            user_index,
+            OrderType::Limit,
+            Side::Bid,
+            TriggerCondition::Above,
+            base_price,
+            base_size,
+            I80F48::from_num(base_price * 1.1),
+        )
+        .await;
+    assert!(advanced_orders_cookie.advanced_orders.orders[0].is_active);
+    assert!(!advanced_orders_cookie.advanced_orders.orders[1].is_active);
+    perp_market
+        .add_trigger_order(
+            &mut test,
+            &mut mango_group_cookie,
+            &mut advanced_orders_cookie,
+            user_index,
+            OrderType::Limit,
+            Side::Bid,
+            TriggerCondition::Below,
+            base_price,
+            base_size,
+            I80F48::from_num(base_price * 0.9),
+        )
+        .await;
+    assert!(advanced_orders_cookie.advanced_orders.orders[0].is_active);
+    assert!(advanced_orders_cookie.advanced_orders.orders[1].is_active);
+
+    // Remove the first advanced order
+    advanced_orders_cookie
+        .remove_advanced_order(&mut test, &mut mango_group_cookie, user_index, 0)
+        .await
+        .expect("deletion succeeds");
+    assert!(!advanced_orders_cookie.advanced_orders.orders[0].is_active);
+    assert!(advanced_orders_cookie.advanced_orders.orders[1].is_active);
+    advanced_orders_cookie
+        .remove_advanced_order(&mut test, &mut mango_group_cookie, user_index, 0)
+        .await
+        .expect("deletion of inactive is ok");
+    advanced_orders_cookie
+        .remove_advanced_order(&mut test, &mut mango_group_cookie, user_index, 2)
+        .await
+        .expect("deletion of unused is ok");
+
+    // Trigger the second advanced order
+    let agent_user_index = user2_index;
+    perp_market
+        .execute_trigger_order(
+            &mut test,
+            &mut mango_group_cookie,
+            &mut advanced_orders_cookie,
+            user_index,
+            agent_user_index,
+            1,
+        )
+        .await
+        .expect_err("order trigger condition should not be met");
+    mango_group_cookie.set_oracle(&mut test, mint_index, base_price * 0.8).await;
+    mango_group_cookie.run_keeper(&mut test).await;
+    perp_market
+        .execute_trigger_order(
+            &mut test,
+            &mut mango_group_cookie,
+            &mut advanced_orders_cookie,
+            user_index,
+            agent_user_index,
+            1,
+        )
+        .await
+        .expect("order executed");
+    assert!(!advanced_orders_cookie.advanced_orders.orders[1].is_active);
+
+    // Check that order is in book now
+    mango_group_cookie.run_keeper(&mut test).await;
+    let user_perp_orders = vec![(user_index, mint_index, Side::Bid, base_size, base_price)];
+    assert_open_perp_orders(&mango_group_cookie, &user_perp_orders, STARTING_ADVANCED_ORDER_ID + 1);
+}


### PR DESCRIPTION
Needs to be run with `cargo test-bpf` because of the pda advanced orders account. But note that other tests fail in that mode (which I plan to look at).