### PR TITLE
Avoid using the destructuring_assignment feature

### DIFF
--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(destructuring_assignment)]
-
 #[macro_use]
 pub mod error;
 

--- a/program/src/matching.rs
+++ b/program/src/matching.rs
@@ -498,7 +498,9 @@ impl BookSide {
             match self.get(child_h).unwrap().case().unwrap() {
                 NodeRef::Inner(inner) => {
                     parent_h = child_h;
-                    (child_h, crit_bit) = inner.walk_down(search_key);
+                    let (new_child_h, new_crit_bit) = inner.walk_down(search_key);
+                    child_h = new_child_h;
+                    crit_bit = new_crit_bit;
                 }
                 NodeRef::Leaf(leaf) => {
                     if leaf.key != search_key {


### PR DESCRIPTION
Because it forces use of non-stable compilers.