### PR TITLE
fix(deposit instruction): incorrect expected accounts count

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -50,7 +50,7 @@ pub enum MangoInstruction {
 
     /// Deposit funds into mango account
     ///
-    /// Accounts expected by this instruction (8):
+    /// Accounts expected by this instruction (9):
     ///
     /// 0. `[]` mango_group_ai - MangoGroup that this mango account is for
     /// 1. `[writable]` mango_account_ai - the mango account for this user


### PR DESCRIPTION
Nine accounts are listed as required as per the instruction