### PR TITLE
Bump syn version to 1.0.82

### DIFF
--- a/mango-macro/Cargo.toml
+++ b/mango-macro/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = "=1.0.74"
+syn = "=1.0.82"
 solana-program = "^1.8.1"
 bytemuck = "^1.7.2"
 quote = "^1.0.9"


### PR DESCRIPTION
Hey team, is it possible to bump syn version to 1.0.82

This is to make syn compatible with Anchor's syn version so mango can be easily added to any Anchor project's dependencies.

If not that's OK too, I will keep using my own fork