### PR TITLE
WIP: mc/flash loan

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -123,6 +123,8 @@ pub enum MangoErrorCode {
     InvalidOraclePrice,
     #[error("MangoErrorCode::MaxAccountsReached The maximum number of accounts for this group has been reached")]
     MaxAccountsReached,
+    #[error("MangoErrorCode::InvalidBalanceAfterFlashLoan")]
+    InvalidBalanceAfterFlashLoan,
 
     #[error("MangoErrorCode::Default Check the source code for more info")]
     Default = u32::MAX_VALUE,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1346,6 +1346,7 @@ impl MangoInstruction {
             58 => MangoInstruction::SetDelegate,
             59 => {
                 let (amount, _cpi_data_vec_len, cpi_data_vec_arr) = array_refs![data, 8, 8;..;];
+
                 MangoInstruction::FlashLoan {
                     liquidity_amount: u64::from_le_bytes(*amount),
                     cpi_data: cpi_data_vec_arr.to_vec(),

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -912,6 +912,12 @@ pub enum MangoInstruction {
     FlashLoan {
         liquidity_amount: u64,
     },
+
+    MarginTrade {
+        num_open_orders: u8,
+        num_tokens_used: u8,
+        cpi_data: Vec<u8>,
+    },
 }
 
 impl MangoInstruction {
@@ -1340,6 +1346,15 @@ impl MangoInstruction {
             59 => {
                 let data = array_ref![data, 0, 8];
                 MangoInstruction::FlashLoan { liquidity_amount: u64::from_le_bytes(*data) }
+            }
+            60 => {
+                let (num_open_orders, num_tokens_used, cpi_data) = array_refs![data, 1, 1; ..;];
+
+                MangoInstruction::MarginTrade {
+                    num_open_orders: u8::from_le_bytes(*num_open_orders),
+                    num_tokens_used: u8::from_le_bytes(*num_tokens_used),
+                    cpi_data: cpi_data.to_vec(),
+                }
             }
             _ => {
                 return None;

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -892,11 +892,11 @@ pub enum MangoInstruction {
     ///   . `[]` token_prog_ai - Token program id.
     ///   . `[]` flash_loan_prog_ai - Flash loan receiver program id.
     ///             Must implement an instruction that has tag of 0 and a signature of `(amount: u64)`
-    ///             This instruction must return the amount to the source liquidity account.
+    ///             This instruction must return the amount to the source account.
     ///   .. `[any]` Additional accounts expected by the receiving program's `ReceiveFlashLoan` instruction.
     ///
     ///   The flash loan receiver program that is to be invoked should contain an instruction with
-    ///   tag `0` and accept the total amount (including fee) that needs to be returned back after
+    ///   tag `0` and accept the total amount that needs to be returned back after
     ///   its execution has completed.
     ///
     ///   Flash loan receiver should have an instruction with the following signature:

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1350,6 +1350,7 @@ impl MangoInstruction {
             58 => MangoInstruction::SetDelegate,
             59 => {
                 let (amount, _cpi_data_vec_len, cpi_data_vec_arr) = array_refs![data, 8, 8;..;];
+                assert!(usize::from_le_bytes(*_cpi_data_vec_len) == cpi_data_vec_arr.len());
 
                 MangoInstruction::FlashLoan {
                     loan_amount: u64::from_le_bytes(*amount),

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -899,6 +899,10 @@ pub enum MangoInstruction {
     ///   tag `0` and accept the total amount that needs to be returned back after
     ///   its execution has completed.
     ///
+    /// Data expected:
+    ///  . loan_amount - size of flash loan
+    ///  . cpi_data - cpi instruction data
+    ///
     ///   Flash loan receiver should have an instruction with the following signature:
     ///
     ///   0. `[writable]` source_token_ai - Source vault (matching the destination from above).

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -910,7 +910,7 @@ pub enum MangoInstruction {
     ///       amount: u64
     ///   }
     FlashLoan {
-        liquidity_amount: u64,
+        loan_amount: u64,
         cpi_data: Vec<u8>,
     },
 
@@ -1348,7 +1348,7 @@ impl MangoInstruction {
                 let (amount, _cpi_data_vec_len, cpi_data_vec_arr) = array_refs![data, 8, 8;..;];
 
                 MangoInstruction::FlashLoan {
-                    liquidity_amount: u64::from_le_bytes(*amount),
+                    loan_amount: u64::from_le_bytes(*amount),
                     cpi_data: cpi_data_vec_arr.to_vec(),
                 }
             }
@@ -2440,7 +2440,7 @@ pub fn flash_loan(
     token_pk: &Pubkey,
     flash_loan_prog_pk: &Pubkey,
     remaining_pks: &[Pubkey],
-    liquidity_amount: u64,
+    loan_amount: u64,
     cpi_data: Vec<u8>,
 ) -> Result<Instruction, ProgramError> {
     let mut accounts = vec![
@@ -2454,7 +2454,7 @@ pub fn flash_loan(
 
     accounts.extend(remaining_pks.iter().map(|pk| AccountMeta::new_readonly(*pk, false)));
 
-    let instr = MangoInstruction::FlashLoan { liquidity_amount, cpi_data };
+    let instr = MangoInstruction::FlashLoan { loan_amount, cpi_data };
     let data = instr.pack();
     Ok(Instruction { program_id: *program_id, accounts, data })
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -5541,11 +5541,7 @@ impl Processor {
         let mango_group = MangoGroup::load_checked(mango_group_ai, program_id)?;
         let source_token = Account::unpack(&source_token_ai.try_borrow_data()?)?;
 
-        let flash_loan_amount = if loan_amount == u64::MAX {
-            source_token.amount
-        } else {
-            min(source_token.amount, loan_amount)
-        };
+        let flash_loan_amount = min(source_token.amount, loan_amount);
 
         let source_balance_before = source_token.amount;
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -5486,9 +5486,17 @@ impl Processor {
         // Determine change in vaults and apply to MangoAccount
         for (i, bank_set) in bank_sets.iter_mut().enumerate() {
             let pre_amount = I80F48::from_num(pre_amounts[i]);
-            let token_account = TokenAccount::load(bank_set.vault_ai)?;
+            let token_account = TokenAccount::load_checked(bank_set.vault_ai)?;
             token_account.check_mango_reqs(&mango_group)?; // make sure only amount changed
+
+            // Make sure mint has not changed
+            check!(
+                token_account.0.mint == mango_group.tokens[bank_set.token_index].mint,
+                MangoErrorCode::InvalidAccountState
+            )?;
+
             let post_amount = I80F48::from_num(token_account.0.amount);
+
             // let post_amount =
             //     I80F48::from_num(Account::unpack(&bank_set.vault_ai.try_borrow_data()?)?.amount);
             let change = post_amount - pre_amount;

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -5325,7 +5325,7 @@ impl Processor {
         accounts: &[AccountInfo],
         num_open_orders: u8,
         num_tokens_used: u8,
-        cpi_data: &[u8],
+        cpi_data: Vec<u8>,
     ) -> MangoResult {
         let num_open_orders = num_open_orders as usize;
         let num_tokens_used = num_tokens_used as usize;
@@ -5476,7 +5476,7 @@ impl Processor {
 
         let cpi_ix = Instruction {
             program_id: *cpi_prog_ai.key,
-            data: cpi_data.to_vec(),
+            data: cpi_data,
             accounts: cpi_account_metas,
         };
 
@@ -6048,6 +6048,10 @@ impl Processor {
             MangoInstruction::FlashLoan { liquidity_amount } => {
                 msg!("Mango: FlashLoan");
                 Self::flash_loan(program_id, accounts, liquidity_amount)
+            }
+            MangoInstruction::MarginTrade { num_open_orders, num_tokens_used, cpi_data } => {
+                msg!("Mango: MarginTrade");
+                Self::margin_trade(program_id, accounts, num_open_orders, num_tokens_used, cpi_data)
             }
         }
     }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -5388,10 +5388,9 @@ impl Processor {
             &flash_loan_instruction_account_infos[..],
         )?;
 
-        let source_token = Account::unpack(&source_token_ai.try_borrow_data()?)?;
-        // todo: fees
-        let source_balance_after = source_token.amount;
+        let source_balance_after = Account::unpack(&source_token_ai.try_borrow_data()?)?.amount;
         check!(
+            // todo: fees
             source_balance_after >= source_balance_before,
             MangoErrorCode::InvalidBalanceAfterFlashLoan
         )?;

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -5522,7 +5522,7 @@ impl Processor {
     fn flash_loan(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
-        liquidity_amount: u64,
+        loan_amount: u64,
         cpi_data: Vec<u8>,
     ) -> MangoResult {
         const NUM_FIXED: usize = 6;
@@ -5541,10 +5541,10 @@ impl Processor {
         let mango_group = MangoGroup::load_checked(mango_group_ai, program_id)?;
         let source_token = Account::unpack(&source_token_ai.try_borrow_data()?)?;
 
-        let flash_loan_amount = if liquidity_amount == u64::MAX {
+        let flash_loan_amount = if loan_amount == u64::MAX {
             source_token.amount
         } else {
-            min(source_token.amount, liquidity_amount)
+            min(source_token.amount, loan_amount)
         };
 
         let source_balance_before = source_token.amount;
@@ -6040,9 +6040,9 @@ impl Processor {
                 msg!("Mango: SetDelegate");
                 Self::set_delegate(program_id, accounts)
             }
-            MangoInstruction::FlashLoan { liquidity_amount, cpi_data } => {
+            MangoInstruction::FlashLoan { loan_amount, cpi_data } => {
                 msg!("Mango: FlashLoan");
-                Self::flash_loan(program_id, accounts, liquidity_amount, cpi_data)
+                Self::flash_loan(program_id, accounts, loan_amount, cpi_data)
             }
             MangoInstruction::MarginTrade { num_open_orders, num_tokens_used, cpi_data } => {
                 msg!("Mango: MarginTrade");

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -5518,6 +5518,7 @@ impl Processor {
 
         Ok(())
     }
+
     fn flash_loan(
         program_id: &Pubkey,
         accounts: &[AccountInfo],

--- a/program/tests/program_test/cookies.rs
+++ b/program/tests/program_test/cookies.rs
@@ -325,6 +325,7 @@ impl MangoGroupCookie {
 
         let (receiver_authority_pubkey, _) =
             Pubkey::find_program_address(&[b"flashloan"], &test.flash_loan_receiver_program_id);
+
         let instructions = [mango::instruction::flash_loan(
             &test.mango_program_id,
             &self.address,
@@ -334,6 +335,12 @@ impl MangoGroupCookie {
             &test.flash_loan_receiver_program_id,
             &[receiver_authority_pubkey],
             amount,
+            {
+                let mut cpi_data = Vec::with_capacity(9);
+                cpi_data.push(0u8);
+                cpi_data.extend_from_slice(&amount.to_le_bytes());
+                cpi_data
+            },
         )
         .unwrap()];
 

--- a/program/tests/program_test/helpers/flash_loan_receiver.rs
+++ b/program/tests/program_test/helpers/flash_loan_receiver.rs
@@ -1,0 +1,143 @@
+use solana_program::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, pubkey::Pubkey,
+};
+
+use crate::helpers::flash_loan_receiver::FlashLoanReceiverError::InvalidInstruction;
+use spl_token::{
+    solana_program::{
+        account_info::next_account_info, program::invoke_signed, program_error::ProgramError,
+        program_pack::Pack,
+    },
+    state::Account,
+};
+use std::cmp::min;
+use std::convert::TryInto;
+use thiserror::Error;
+
+pub enum FlashLoanReceiverInstruction {
+    /// Receive a flash loan and perform user-defined operation and finally return the fund back.
+    ///
+    /// Accounts expected:
+    ///
+    ///   0. `[writable]` Source liquidity (matching the destination from above).
+    ///   1. `[writable]` Destination liquidity (matching the source from above).
+    ///   2. `[]` Token program id
+    ///   .. `[any]` Additional accounts provided to the lending program's `FlashLoan` instruction above.
+    ReceiveFlashLoan {
+        /// The amount that is loaned
+        amount: u64,
+    },
+}
+
+entrypoint!(process_instruction);
+pub fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    Processor::process(program_id, accounts, instruction_data)
+}
+
+pub struct Processor;
+impl Processor {
+    pub fn process(
+        program_id: &Pubkey,
+        accounts: &[AccountInfo],
+        instruction_data: &[u8],
+    ) -> ProgramResult {
+        let instruction = FlashLoanReceiverInstruction::unpack(instruction_data)?;
+
+        match instruction {
+            FlashLoanReceiverInstruction::ReceiveFlashLoan { amount } => {
+                msg!("Instruction: Receive Flash Loan");
+                Self::process_receive_flash_loan(accounts, amount, program_id)
+            }
+        }
+    }
+
+    fn process_receive_flash_loan(
+        accounts: &[AccountInfo],
+        amount: u64,
+        program_id: &Pubkey,
+    ) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+        let source_liquidity_token_account_info = next_account_info(account_info_iter)?;
+        let destination_liquidity_token_account_info = next_account_info(account_info_iter)?;
+        let token_program_id = next_account_info(account_info_iter)?;
+        let program_derived_account_info = next_account_info(account_info_iter)?;
+
+        let source_liquidity_token_account = Account::unpack_from_slice(
+            &source_liquidity_token_account_info.try_borrow_mut_data()?,
+        )?;
+        let (expected_program_derived_account_pubkey, bump_seed) =
+            Pubkey::find_program_address(&[b"flashloan"], program_id);
+
+        if &expected_program_derived_account_pubkey != program_derived_account_info.key {
+            msg!("Supplied program derived account doesn't match with expectation.")
+        }
+
+        if source_liquidity_token_account.owner != expected_program_derived_account_pubkey {
+            return Err(ProgramError::IncorrectProgramId);
+        }
+
+        let balance_in_token_account =
+            Account::unpack_from_slice(&source_liquidity_token_account_info.try_borrow_data()?)?
+                .amount;
+        let transfer_ix = spl_token::instruction::transfer(
+            token_program_id.key,
+            source_liquidity_token_account_info.key,
+            destination_liquidity_token_account_info.key,
+            &expected_program_derived_account_pubkey,
+            &[],
+            min(balance_in_token_account, amount),
+        )?;
+
+        invoke_signed(
+            &transfer_ix,
+            &[
+                source_liquidity_token_account_info.clone(),
+                destination_liquidity_token_account_info.clone(),
+                program_derived_account_info.clone(),
+                token_program_id.clone(),
+            ],
+            &[&[&b"flashloan"[..], &[bump_seed]]],
+        )?;
+
+        Ok(())
+    }
+}
+
+impl FlashLoanReceiverInstruction {
+    pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
+        let (tag, rest) = input.split_first().ok_or(InvalidInstruction)?;
+
+        Ok(match tag {
+            0 => Self::ReceiveFlashLoan { amount: Self::unpack_amount(rest)? },
+            _ => return Err(InvalidInstruction.into()),
+        })
+    }
+
+    fn unpack_amount(input: &[u8]) -> Result<u64, ProgramError> {
+        let amount = input
+            .get(..8)
+            .and_then(|slice| slice.try_into().ok())
+            .map(u64::from_le_bytes)
+            .ok_or(InvalidInstruction)?;
+        Ok(amount)
+    }
+}
+
+#[derive(Error, Debug, Copy, Clone)]
+pub enum FlashLoanReceiverError {
+    /// Invalid instruction
+    #[error("Invalid Instruction")]
+    InvalidInstruction,
+    #[error("The account is not currently owned by the program")]
+    IncorrectProgramId,
+}
+
+impl From<FlashLoanReceiverError> for ProgramError {
+    fn from(e: FlashLoanReceiverError) -> Self {
+        ProgramError::Custom(e as u32)
+    }
+}

--- a/program/tests/program_test/helpers/mod.rs
+++ b/program/tests/program_test/helpers/mod.rs
@@ -1,0 +1,1 @@
+pub mod flash_loan_receiver;

--- a/program/tests/program_test/scenarios.rs
+++ b/program/tests/program_test/scenarios.rs
@@ -1,4 +1,6 @@
 use crate::*;
+use solana_program::entrypoint::ProgramResult;
+use solana_program::pubkey::Pubkey;
 use solana_sdk::transport::TransportError;
 
 #[allow(dead_code)]
@@ -186,4 +188,14 @@ pub async fn match_perp_order_scenario(
         mango_group_cookie.consume_perp_events(test).await;
         mango_group_cookie.run_keeper(test).await;
     }
+}
+
+#[allow(dead_code)]
+pub async fn flash_loan_scenario(
+    test: &mut MangoProgramTest,
+    mango_group_cookie: &mut MangoGroupCookie,
+    mint_index: usize,
+    amount: u64,
+) -> Result<(), TransportError> {
+    mango_group_cookie.flash_loan(test, mint_index, amount).await
 }

--- a/program/tests/test_flash_loan.rs
+++ b/program/tests/test_flash_loan.rs
@@ -51,3 +51,21 @@ async fn test_flash_loan() {
 
     assert!(balance_before >= balance_after)
 }
+//
+// #[tokio::test]
+// async fn test_margin_trade() {
+//     // === Arrange ===
+//     let config = MangoProgramTestConfig { compute_limit: 200_000, num_users: 2, num_mints: 2 };
+//     let mut test = MangoProgramTest::start_new(&config).await;
+//
+//     let mut mango_group_cookie = MangoGroupCookie::default(&mut test).await;
+//     mango_group_cookie.full_setup(&mut test, config.num_users, config.num_mints - 1).await;
+//
+//     // General parameters
+//     let user_index: usize = 0;
+//     let mint_index: usize = 1;
+//     let base_price: f64 = 10_000.0;
+//
+//     // Deposit amounts
+//     let user_deposits = vec![(user_index, test.quote_index, base_price * 3.)];
+// }

--- a/program/tests/test_flash_loan.rs
+++ b/program/tests/test_flash_loan.rs
@@ -1,0 +1,53 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use fixed::types::I80F48;
+use solana_program::program_option::COption;
+use solana_program::pubkey::Pubkey;
+use solana_program_test::processor;
+use solana_program_test::*;
+use solana_sdk::signature::Keypair;
+use solana_sdk::signature::Signer;
+use spl_token::state::{Account, AccountState};
+
+use mango::instruction::flash_loan;
+use mango::state::{QUOTE_INDEX, ZERO_I80F48};
+use program_test::assertions::*;
+use program_test::cookies::*;
+use program_test::scenarios::*;
+use program_test::*;
+
+use crate::tokio::time::sleep;
+
+mod program_test;
+#[tokio::test]
+async fn test_flash_loan() {
+    // === Arrange ===
+    let config = MangoProgramTestConfig { compute_limit: 200_000, num_users: 2, num_mints: 2 };
+    let mut test = MangoProgramTest::start_new(&config).await;
+
+    let mut mango_group_cookie = MangoGroupCookie::default(&mut test).await;
+    mango_group_cookie.full_setup(&mut test, config.num_users, config.num_mints - 1).await;
+
+    // General parameters
+    let user_index: usize = 0;
+    let mint_index: usize = 1;
+    let base_price: f64 = 10_000.0;
+
+    // Deposit amounts
+    let user_deposits = vec![(user_index, test.quote_index, base_price * 3.)];
+
+    let (_, root_bank) = test.with_root_bank(&mango_group_cookie.mango_group, mint_index).await;
+    let (_, node_bank) = test.with_node_bank(&root_bank, 0).await;
+
+    // === Act ===
+    // Step 1: Make deposits
+    deposit_scenario(&mut test, &mut mango_group_cookie, &user_deposits).await;
+    let balance_before = test.get_token_balance(node_bank.vault).await;
+
+    // Step 2: Make flash loan
+    flash_loan_scenario(&mut test, &mut mango_group_cookie, mint_index, 100_000_000).await.unwrap();
+    let balance_after = test.get_token_balance(node_bank.vault).await;
+
+    assert!(balance_before >= balance_after)
+}


### PR DESCRIPTION
Remaining must do tasks
- [ ]  add fees
- [ ] security review
- [ ] test/working-example for margin trade


Open questions
- [ ] flash loan - keep or remove in favor of margin trade
- [ ] margin trade - keep or remove in favor of flash loan
- [ ] Some common use cases for flash loans is collateral swapping and preventing self liquidation, wouldn't mango program be an ideal cpi program in this case? Would we then want to remove the check to not be able to cpi into mango program? This condition is necessary for daffy's margin trade instruction since it passes signer seeds but not technically necessary for the flash loan instruction since that explicitly does token transfer before doing the cpi
- [ ] should we strive for abi closer to spl-token-lending?
