### PR TITLE
fix: remove unused account from ix interface spec

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -78,8 +78,7 @@ pub enum MangoInstruction {
     /// 7. `[write]` token_account_ai, -
     /// 8. `[read]` signer_ai,        -
     /// 9. `[read]` token_prog_ai,    -
-    /// 10. `[read]` clock_ai,         -
-    /// 11..+ `[]` open_orders_accs - open orders for each of the spot market
+    /// 10..+ `[]` open_orders_accs - open orders for each of the spot market
     Withdraw {
         quantity: u64,
         allow_borrow: bool,


### PR DESCRIPTION
`clock_ai` account is specified in the instruction interface, however it's not used in the processor.
The withdraw ix will work under some conditions, while the `clock_ai` might be interpreted as an `open_orders` account, and cause the ix to fail.

```rust
let (fixed_ais, open_orders_ais) = array_refs![accounts, NUM_FIXED, MAX_PAIRS];
let [
    mango_group_ai,     // read
    mango_account_ai,   // write
    owner_ai,           // read
    mango_cache_ai,     // read
    root_bank_ai,       // read
    node_bank_ai,       // write
    vault_ai,           // write
    token_account_ai,   // write
    signer_ai,          // read
    token_prog_ai,      // read
] = fixed_ais;
```