### PR TITLE
add payer accounts to pda-creation instructions

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -836,12 +836,13 @@ pub enum MangoInstruction {
 
     /// Create a PDA mango account for a user
     ///
-    /// Accounts expected by this instruction (4):
+    /// Accounts expected by this instruction (5):
     ///
     /// 0. `[writable]` mango_group_ai - MangoGroup that this mango account is for
     /// 1. `[writable]` mango_account_ai - the mango account data
     /// 2. `[signer]` owner_ai - Solana account of owner of the mango account
     /// 3. `[]` system_prog_ai - System program
+    /// 4. `[signer, writable]` payer_ai - pays for the PDA creation
     CreateMangoAccount {
         account_num: u64,
     },
@@ -912,7 +913,7 @@ pub enum MangoInstruction {
 
     /// Create an OpenOrders PDA and initialize it with InitOpenOrders call to serum dex
     ///
-    /// Accounts expected by this instruction (8):
+    /// Accounts expected by this instruction (9):
     ///
     /// 0. `[]` mango_group_ai - MangoGroup that this mango account is for
     /// 1. `[writable]` mango_account_ai - MangoAccount
@@ -922,6 +923,7 @@ pub enum MangoInstruction {
     /// 5. `[]` spot_market_ai - dex MarketState account
     /// 6. `[]` signer_ai - Group Signer Account
     /// 7. `[]` system_prog_ai - System program
+    /// 8. `[signer, writable]` payer_ai - pays for the PDA creation
     CreateSpotOpenOrders, // instruction 60
 }
 
@@ -1539,13 +1541,15 @@ pub fn create_mango_account(
     mango_account_pk: &Pubkey,
     owner_pk: &Pubkey,
     system_prog_pk: &Pubkey,
+    payer_pk: &Pubkey,
     account_num: u64,
 ) -> Result<Instruction, ProgramError> {
     let accounts = vec![
         AccountMeta::new(*mango_group_pk, false),
         AccountMeta::new(*mango_account_pk, false),
-        AccountMeta::new(*owner_pk, true),
+        AccountMeta::new_readonly(*owner_pk, true),
         AccountMeta::new_readonly(*system_prog_pk, false),
+        AccountMeta::new(*payer_pk, true),
     ];
 
     let instr = MangoInstruction::CreateMangoAccount { account_num };
@@ -2221,16 +2225,18 @@ pub fn create_spot_open_orders(
     open_orders_pk: &Pubkey,
     spot_market_pk: &Pubkey,
     signer_pk: &Pubkey,
+    payer_pk: &Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let accounts = vec![
         AccountMeta::new_readonly(*mango_group_pk, false),
         AccountMeta::new(*mango_account_pk, false),
-        AccountMeta::new(*owner_pk, true),
+        AccountMeta::new_readonly(*owner_pk, true),
         AccountMeta::new_readonly(*dex_prog_pk, false),
         AccountMeta::new(*open_orders_pk, false),
         AccountMeta::new_readonly(*spot_market_pk, false),
         AccountMeta::new_readonly(*signer_pk, false),
         AccountMeta::new_readonly(solana_program::system_program::ID, false),
+        AccountMeta::new(*payer_pk, true),
     ];
 
     let instr = MangoInstruction::CreateSpotOpenOrders;

--- a/program/tests/test_create_account.rs
+++ b/program/tests/test_create_account.rs
@@ -1,0 +1,62 @@
+use solana_program_test::*;
+use solana_sdk::signature::Signer;
+use solana_sdk::signer::keypair::Keypair;
+
+use mango::state::{MangoAccount, ZERO_I80F48};
+use program_test::cookies::*;
+use program_test::*;
+
+mod program_test;
+
+#[tokio::test]
+async fn test_create_account() {
+    // === Arrange ===
+    let config = MangoProgramTestConfig { compute_limit: 200_000, num_users: 2, num_mints: 2 };
+    let mut test = MangoProgramTest::start_new(&config).await;
+
+    let mut mango_group_cookie = MangoGroupCookie::default(&mut test).await;
+    let num_precreated_mango_users = 0; // create manually
+    mango_group_cookie
+        .full_setup(&mut test, num_precreated_mango_users, config.num_mints - 1)
+        .await;
+
+    let mango_group_pk = &mango_group_cookie.address;
+
+    //
+    // paid for by owner (test.users[0])
+    //
+    let account0_pk = test.create_mango_account(mango_group_pk, 0, 0, None).await;
+    test.create_spot_open_orders(
+        mango_group_pk,
+        &mango_group_cookie.mango_group,
+        &account0_pk,
+        0,
+        0,
+        None,
+    )
+    .await;
+
+    //
+    // paid for by separate payer (test.users[1]) still owned by test.users[0]
+    //
+    let payer = Keypair::from_base58_string(&test.users[1].to_base58_string());
+    let payer_lamports = test.get_lamport_balance(payer.pubkey()).await;
+    let owner_lamports = test.get_lamport_balance(test.users[0].pubkey()).await;
+    let account1_pk = test.create_mango_account(mango_group_pk, 0, 1, Some(&payer)).await;
+    let account1 = test.load_account::<MangoAccount>(account1_pk).await;
+    assert_eq!(account1.owner, test.users[0].pubkey());
+    assert_eq!(test.get_lamport_balance(test.users[0].pubkey()).await, owner_lamports);
+    assert!(test.get_lamport_balance(payer.pubkey()).await < payer_lamports);
+    assert!(account0_pk != account1_pk);
+
+    test.create_spot_open_orders(
+        mango_group_pk,
+        &mango_group_cookie.mango_group,
+        &account1_pk,
+        0,
+        0,
+        Some(&payer),
+    )
+    .await;
+    assert_eq!(test.get_lamport_balance(test.users[0].pubkey()).await, owner_lamports);
+}


### PR DESCRIPTION
Add a new optional account to
- create_mango_account
- create_spot_open_orders
that pays for the creation of the new account.

If you want to compose on mango and have a PDA account as an owner, it's
impossible to also use it as a payer because accounts with data cannot
pay for PDA creation.