### PR TITLE
Reduce max number of consumed events further

### DIFF
--- a/program/src/matching.rs
+++ b/program/src/matching.rs
@@ -1183,6 +1183,12 @@ impl<'a> Book<'a> {
                 ref_fee_rate.unwrap(),
                 &mango_cache.perp_market_cache[market_index],
             );
+
+            // Track maker fees immediately: they can be negative and applying them later
+            // risks that fees_accrued has been settled to 0. It going negative breaks assumptions.
+            let total_quote_native =
+                I80F48::from_num(market.quote_lot_size.checked_mul(total_quote_taken).unwrap());
+            market.fees_accrued += total_quote_native * info.maker_fee;
         }
 
         Ok(())
@@ -1379,6 +1385,12 @@ impl<'a> Book<'a> {
                 ref_fee_rate.unwrap(),
                 &mango_cache.perp_market_cache[market_index],
             );
+
+            // Track maker fees immediately: they can be negative and applying them later
+            // risks that fees_accrued has been settled to 0. It going negative breaks assumptions.
+            let total_quote_native =
+                I80F48::from_num(market.quote_lot_size.checked_mul(total_quote_taken).unwrap());
+            market.fees_accrued += total_quote_native * info.maker_fee;
         }
 
         Ok(())

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -4420,8 +4420,8 @@ impl Processor {
         accounts: &[AccountInfo],
         limit: usize,
     ) -> MangoResult<()> {
-        // Limit may be max 10 because of compute limits from logging. Increase if compute goes up
-        let limit = min(limit, 6);
+        // Limit may be max 4 because of compute and memory limits from logging. Increase if compute/mem goes up
+        let limit = min(limit, 4);
 
         const NUM_FIXED: usize = 4;
         let (fixed_ais, mango_account_ais) = array_refs![accounts, NUM_FIXED; ..;];

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -1622,7 +1622,6 @@ impl MangoAccount {
         pa.change_base_position(perp_market, base_change);
         let quote = I80F48::from_num(perp_market.quote_lot_size.checked_mul(quote_change).unwrap());
         let fees = quote.abs() * fill.maker_fee;
-        perp_market.fees_accrued += fees;
         pa.quote_position = pa.quote_position.checked_add(quote - fees).unwrap();
 
         // if versions don't match, no LM


### PR DESCRIPTION
We saw memory allocation failures with six events being processed.