### PR TITLE
Add tests for perp order types

### DIFF
--- a/program/tests/program_test/scenarios.rs
+++ b/program/tests/program_test/scenarios.rs
@@ -175,11 +175,12 @@ pub async fn match_spot_order_scenario(
     matched_spot_orders: &Vec<Vec<(usize, usize, serum_dex::matching::Side, f64, f64)>>,
 ) {
     for matched_spot_order in matched_spot_orders {
+        // place_spot_order_scenario() starts by running the keeper
         place_spot_order_scenario(test, mango_group_cookie, matched_spot_order).await;
         mango_group_cookie.run_keeper(test).await;
         mango_group_cookie.consume_spot_events(test).await;
-        mango_group_cookie.run_keeper(test).await;
     }
+    mango_group_cookie.run_keeper(test).await;
 }
 
 #[allow(dead_code)]
@@ -189,9 +190,10 @@ pub async fn match_perp_order_scenario(
     matched_perp_orders: &Vec<Vec<(usize, usize, mango::matching::Side, f64, f64)>>,
 ) {
     for matched_perp_order in matched_perp_orders {
+        // place_perp_order_scenario() starts by running the keeper
         place_perp_order_scenario(test, mango_group_cookie, matched_perp_order).await;
         mango_group_cookie.run_keeper(test).await;
         mango_group_cookie.consume_perp_events(test).await;
-        mango_group_cookie.run_keeper(test).await;
     }
+    mango_group_cookie.run_keeper(test).await;
 }

--- a/program/tests/test_liquidation_perp_market_max_cu.rs
+++ b/program/tests/test_liquidation_perp_market_max_cu.rs
@@ -108,11 +108,11 @@ async fn test_liquidation_perp_market_max_cu() {
         ];
         deposit_scenario(&mut test, &mut mango_group_cookie, &user_deposits).await;
 
-        let matched_spot_orders = vec![vec![
+        let placed_spot_orders = vec![
             (bidder_user_index, market_index, serum_dex::matching::Side::Bid, base_size, 0.9),
             (asker_user_index, market_index, serum_dex::matching::Side::Ask, base_size, 1.1),
-        ]];
-        match_spot_order_scenario(&mut test, &mut mango_group_cookie, &matched_spot_orders).await;
+        ];
+        place_spot_order_scenario(&mut test, &mut mango_group_cookie, &placed_spot_orders).await;
 
         let matched_perp_orders = vec![vec![
             (asker_user_index, market_index, mango::matching::Side::Ask, base_size, 1.),

--- a/program/tests/test_liquidation_token_and_perp_max_cu.rs
+++ b/program/tests/test_liquidation_token_and_perp_max_cu.rs
@@ -130,11 +130,11 @@ async fn test_liquidation_token_and_perp_max_cu() {
         ];
         deposit_scenario(&mut test, &mut mango_group_cookie, &user_deposits).await;
 
-        let matched_spot_orders = vec![vec![
+        let placed_spot_orders = vec![
             (bidder_user_index, market_index, serum_dex::matching::Side::Bid, base_size, 0.9),
             (asker_user_index, market_index, serum_dex::matching::Side::Ask, base_size, 1.1),
-        ]];
-        match_spot_order_scenario(&mut test, &mut mango_group_cookie, &matched_spot_orders).await;
+        ];
+        place_spot_order_scenario(&mut test, &mut mango_group_cookie, &placed_spot_orders).await;
 
         let matched_perp_orders = vec![vec![
             (asker_user_index, market_index, mango::matching::Side::Ask, base_size, 1.),

--- a/program/tests/test_liquidation_token_and_token_max_cu.rs
+++ b/program/tests/test_liquidation_token_and_token_max_cu.rs
@@ -105,11 +105,11 @@ async fn test_liquidation_token_and_token_max_cu() {
         ];
         deposit_scenario(&mut test, &mut mango_group_cookie, &user_deposits).await;
 
-        let matched_spot_orders = vec![vec![
+        let placed_spot_orders = vec![
             (bidder_user_index, market_index, serum_dex::matching::Side::Bid, base_size, 0.9),
             (asker_user_index, market_index, serum_dex::matching::Side::Ask, base_size, 1.1),
-        ]];
-        match_spot_order_scenario(&mut test, &mut mango_group_cookie, &matched_spot_orders).await;
+        ];
+        place_spot_order_scenario(&mut test, &mut mango_group_cookie, &placed_spot_orders).await;
 
         let matched_perp_orders = vec![vec![
             (asker_user_index, market_index, mango::matching::Side::Ask, base_size, 1.),


### PR DESCRIPTION
These tests are not detailed enough to detect subtle bugs, but will catch big things like the div-by-zero issue.