### PR TITLE
group doesnt need to be writable in ix builder for withdraw

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -2295,7 +2295,7 @@ pub fn withdraw(
     allow_borrow: bool,
 ) -> Result<Instruction, ProgramError> {
     let mut accounts = vec![
-        AccountMeta::new(*mango_group_pk, false),
+        AccountMeta::new_readonly(*mango_group_pk, false),
         AccountMeta::new(*mango_account_pk, false),
         AccountMeta::new_readonly(*owner_pk, true),
         AccountMeta::new_readonly(*mango_cache_pk, false),


### PR DESCRIPTION
Fixes https://github.com/blockworks-foundation/mango-v3/issues/153

Signed-off-by: microwavedcola1 <microwavedcola@gmail.com>