### PR TITLE
double valid interval for PriceCache

### DIFF
--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -599,6 +599,9 @@ pub struct PriceCache {
 
 impl PriceCache {
     pub fn check_valid(&self, mango_group: &MangoGroup, now_ts: u64) -> MangoResult<()> {
+        // Hack: explicitly double valid_interval as a quick fix to make Mango
+        // less likely to become unusable when solana reliability goes bad.
+        // There's currently no instruction to change the valid_interval.
         check!(
             self.last_update >= now_ts - (2 * mango_group.valid_interval),
             MangoErrorCode::InvalidPriceCache

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -600,7 +600,7 @@ pub struct PriceCache {
 impl PriceCache {
     pub fn check_valid(&self, mango_group: &MangoGroup, now_ts: u64) -> MangoResult<()> {
         check!(
-            self.last_update >= now_ts - mango_group.valid_interval,
+            self.last_update >= now_ts - (2 * mango_group.valid_interval),
             MangoErrorCode::InvalidPriceCache
         )
     }
@@ -634,7 +634,7 @@ pub struct PerpMarketCache {
 impl PerpMarketCache {
     pub fn check_valid(&self, mango_group: &MangoGroup, now_ts: u64) -> MangoResult<()> {
         check!(
-            self.last_update >= now_ts - mango_group.valid_interval,
+            self.last_update >= now_ts - (2 * mango_group.valid_interval),
             MangoErrorCode::InvalidPerpMarketCache
         )
     }


### PR DESCRIPTION
double valid interval for price cache--it's low risk and should help with the number of InvalidPriceCache we get during network instability