### PR TITLE
Remove pyth status check and slot validity entirely

### DIFF
--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -49,7 +49,6 @@ pub const FREE_ORDER_SLOT: u8 = u8::MAX;
 pub const MAX_NUM_IN_MARGIN_BASKET: u8 = 9;
 pub const INDEX_START: I80F48 = I80F48!(1_000_000);
 pub const PYTH_CONF_FILTER: I80F48 = I80F48!(0.10); // filter out pyth prices with conf > 10% of price
-pub const PYTH_VALID_SLOTS: u64 = 50; // Accept Pyth updates up to 50 slots behind
 pub const CENTIBPS_PER_UNIT: I80F48 = I80F48!(1_000_000);
 
 declare_check_assert_macros!(SourceFileId::State);


### PR DESCRIPTION
Pyth status checks completely freeze the system which is more dangerous than errant publisher. We still have conf interval checks