### PR TITLE
Update CI (and updated secret PAT)

### DIFF
--- a/.github/workflows/ci-uxd.yml
+++ b/.github/workflows/ci-uxd.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: UXDProtocol/uxd-program
-          ref: v2.3.1 # detached branch before the audited v3.0.0
+          ref: main
           # GitHub's personal access token with access to repository
           token: ${{ secrets.MANGO_CI_UXD }}
           persist-credentials: false


### PR DESCRIPTION
- Update target branch
- Updated Mango org secret with a new PAT

This is now targeting back the main branch, and run the unit tests successfully.

Previous issue was that someone internally removed the Token permissions. 

Sorry for the inconvenience and thanks again for having our little CI part of 🥭 repo