### PR TITLE
Add Associated Token Accounts owner check during withdraw

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -123,6 +123,8 @@ pub enum MangoErrorCode {
     InvalidOraclePrice,
     #[error("MangoErrorCode::MaxAccountsReached The maximum number of accounts for this group has been reached")]
     MaxAccountsReached,
+    #[error("MangoErrorCode::InvalidAccountOwner")]
+    InvalidAccountOwner,
 
     #[error("MangoErrorCode::Default Check the source code for more info")] // 40
     Default = u32::MAX_VALUE,

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1319,6 +1319,8 @@ impl Processor {
             -withdraw,
         )?;
 
+        let token_account = Account::unpack(&token_account_ai.try_borrow_data()?)?;
+        check!(&token_account.owner == owner_ai.key, MangoErrorCode::InvalidAccountOwner)?;
         let signers_seeds = gen_signer_seeds(&mango_group.signer_nonce, mango_group_ai.key);
         invoke_transfer(
             token_prog_ai,


### PR DESCRIPTION
Associated Token Accounts(ATA) ownership is transferable which is generally not normal

In case of a scenario where a user might have signed some malicious transactions in which the spammer had taken over the ownership of the user's ATA say-USDC, now if the user unknowingly tries to withdraw from the mango account the funds will get transferred to the USDC ATA owned by the spammer and not the user.

Below is the transaction in which I tried replicating the above scenario:  where its deterministic USDC ATA  is not owned by the user and tries withdrawing 5 USDC from mango

user wallet :  DC9wKR6F1PsLzjs1PikthtNaKtVfUeBCc4EUeHhsBLA1
spammer WALLET : 5yFs5rrUGqdwAww69DV6derLUZccs5zUQU6oe2BzUcop
user deterministic USDC ATA owner by spammer : 8nTLNSgkoFXpkLT6z4Y1hS6f49n3yaXruTTrCKmPCYK5

https://explorer.solana.com/tx/4dbGe7wxMPiQeVsEvceJCSZfDxD84M3pKzbykXY9nuw7ePEL5ApQ4tuzNcyTust7nNqfWJEPRX1FcewCUQY4qtVt?cluster=mainnet