### PR TITLE
Load serum_dex dependency with a commit ref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "serum_dex"
 version = "0.5.5"
-source = "git+https://github.com/blockworks-foundation/serum-dex.git#7f55a5ef5f7937b74381a3124021a261cd7d7283"
+source = "git+https://github.com/blockworks-foundation/serum-dex.git?rev=7f55a5ef5f7937b74381a3124021a261cd7d7283#7f55a5ef5f7937b74381a3124021a261cd7d7283"
 dependencies = [
  "arrayref",
  "bincode",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -24,7 +24,7 @@ enumflags2 = "^0.6.4"
 num_enum = "^0.5.1"
 thiserror = "^1.0.24"
 spl-token = { version = "^3.0.0", features = ["no-entrypoint"] }
-serum_dex = { version = "0.5.5", git = "https://github.com/blockworks-foundation/serum-dex.git", default-features=false, features = ["no-entrypoint", "program"] }
+serum_dex = { rev = "7f55a5ef5f7937b74381a3124021a261cd7d7283", git = "https://github.com/blockworks-foundation/serum-dex.git", default-features=false, features = ["no-entrypoint", "program"] }
 static_assertions = "^1.1.0"
 safe-transmute = "^0.11.1"
 mango-macro = { path = "../mango-macro" }


### PR DESCRIPTION
## Problem
Recently the mango fork of `serum_dex` was [merged](https://github.com/blockworks-foundation/serum-dex/commit/7f55a5ef5f7937b74381a3124021a261cd7d7283) with the upstream version 0.5.5. 
The main mango program is importing the `serum_dex` package with version `0.4.0` from a git repository.

If you delete Cargo.lock, the build will fail with 
```
cargo build-bpf
Failed to obtain package metadata: `cargo metadata` exited with an error:     Updating git repository `https://github.com/blockworks-foundation/serum-dex.git`
error: failed to select a version for the requirement `serum_dex = "^0.4.0"`
candidate versions found which didn't match: 0.5.5
location searched: Git repository https://github.com/blockworks-foundation/serum-dex.git
required by package `mango v3.4.3 (/Users/jakob/Projects/crypto/blockworks-foundation/mango-v3/program)`
```
because while Cargo.toml specifies version `0.4.0`, when importing from a git repo, the latest `0.5.5` from upstream is used.

### Fix
Build with `serum_dex 0.5.5` is breaking
```
error[E0063]: missing field `max_ts` in initializer of `NewOrderInstructionV3`
    --> program/src/instruction.rs:1621:10
     |
1621 |     Some(serum_dex::instruction::NewOrderInstructionV3 {
     |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `max_ts`

error[E0061]: this function takes 1 argument but 0 arguments were supplied
    --> program/src/state.rs:2302:11
     |
2302 |     state.check_flags()?;
     |           ^^^^^^^^^^^- supplied 0 arguments
     |           |
     |           expected 1 argument
     |
note: associated function defined here
    --> /Users/jakob/.cargo/git/checkouts/serum-dex-ac3ff2707f895b6e/7f55a5e/dex/src/state.rs:440:12
     |
440  |     pub fn check_flags(&self, allow_disabled: bool) -> DexResult {
```
 so as a quick fix, I removed the version from the `serum_dex` and fixated it to the [commit](https://github.com/blockworks-foundation/serum-dex/commit/3104f424ee38a415418a1cdef67970771f832857) before the upstream merge.
