### PR TITLE
Pointer width agnostic data type sizes

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -429,7 +429,7 @@ impl Processor {
         let market_index = mango_group.find_oracle_index(oracle_ai.key).ok_or(throw!())?;
 
         // This will catch the issue if oracle_ai.key == Pubkey::Default
-        check!(market_index < mango_group.num_oracles, MangoErrorCode::InvalidParam)?;
+        check!(market_index < mango_group.num_oracles as usize, MangoErrorCode::InvalidParam)?;
 
         // Make sure spot market at this index not already initialized
         check!(
@@ -537,7 +537,7 @@ impl Processor {
             }
         }
 
-        let oracle_index = mango_group.num_oracles;
+        let oracle_index = mango_group.num_oracles as usize;
         mango_group.oracles[oracle_index] = *oracle_ai.key;
         mango_group.num_oracles += 1;
 
@@ -622,7 +622,7 @@ impl Processor {
         let market_index = mango_group.find_oracle_index(oracle_ai.key).ok_or(throw!())?;
 
         // This will catch the issue if oracle_ai.key == Pubkey::Default
-        check!(market_index < mango_group.num_oracles, MangoErrorCode::InvalidParam)?;
+        check!(market_index < mango_group.num_oracles as usize, MangoErrorCode::InvalidParam)?;
 
         // Make sure perp market at this index not already initialized
         check!(mango_group.perp_markets[market_index].is_empty(), MangoErrorCode::InvalidParam)?;
@@ -756,7 +756,7 @@ impl Processor {
         let market_index = mango_group.find_oracle_index(oracle_ai.key).ok_or(throw!())?;
 
         // This will catch the issue if oracle_ai.key == Pubkey::Default
-        check!(market_index < mango_group.num_oracles, MangoErrorCode::InvalidParam)?;
+        check!(market_index < mango_group.num_oracles as usize, MangoErrorCode::InvalidParam)?;
 
         // Make sure perp market at this index not already initialized
         check!(mango_group.perp_markets[market_index].is_empty(), MangoErrorCode::InvalidParam)?;
@@ -1649,7 +1649,7 @@ impl Processor {
         check_eq!(&quote_node_bank.vault, quote_vault_ai.key, MangoErrorCode::InvalidVault)?;
 
         // Fix the margin basket incase there are empty ones; main benefit is freeing up basket space
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize {
             if mango_account.in_margin_basket[i] {
                 let open_orders = load_open_orders(&open_orders_ais[i])?;
                 mango_account.update_basket(i, &open_orders)?;
@@ -1927,7 +1927,7 @@ impl Processor {
         let open_orders_accounts = load_open_orders_accounts(&open_orders_ais)?;
 
         // Fix the margin basket incase there are empty ones; main benefit is freeing up basket space
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize {
             if mango_account.in_margin_basket[i] {
                 let open_orders = load_open_orders(open_orders_ais[i].unwrap())?;
                 mango_account.update_basket(i, &open_orders)?;
@@ -3458,7 +3458,7 @@ impl Processor {
         )?;
 
         // Make sure orders are cancelled for perps and check orders
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize {
             if liqee_active_assets.perps[i] {
                 check!(liqee_ma.perp_accounts[i].has_no_open_orders(), MangoErrorCode::Default)?;
             }
@@ -3676,7 +3676,7 @@ impl Processor {
         )?;
 
         // Make sure orders are cancelled for perps and check orders
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize {
             if liqee_active_assets.perps[i] {
                 check!(liqee_ma.perp_accounts[i].has_no_open_orders(), MangoErrorCode::Default)?;
             }
@@ -4000,7 +4000,7 @@ impl Processor {
         liqor_ma.perp_accounts[market_index].settle_funding(cache);
 
         // Make sure orders are cancelled for perps before liquidation
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize {
             if liqee_active_assets.perps[i] {
                 check!(liqee_ma.perp_accounts[i].has_no_open_orders(), MangoErrorCode::Default)?;
             }
@@ -5564,7 +5564,7 @@ impl Processor {
         let mut mango_account =
             MangoAccount::load_mut_checked(mango_account_ai, program_id, mango_group_ai.key)?;
 
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize {
             check_eq!(
                 open_orders_ais[i].key,
                 &mango_account.spot_open_orders[i],
@@ -6349,7 +6349,7 @@ impl Processor {
             }
             MangoInstruction::ConsumeEvents { limit } => {
                 msg!("Mango: ConsumeEvents limit={}", limit);
-                Self::consume_events(program_id, accounts, limit)
+                Self::consume_events(program_id, accounts, limit as usize)
             }
             MangoInstruction::CachePerpMarkets => {
                 msg!("Mango: CachePerpMarkets");
@@ -6366,7 +6366,7 @@ impl Processor {
             }
             MangoInstruction::SettlePnl { market_index } => {
                 msg!("Mango: SettlePnl");
-                Self::settle_pnl(program_id, accounts, market_index)
+                Self::settle_pnl(program_id, accounts, market_index as usize)
             }
             MangoInstruction::SettleBorrow { .. } => {
                 msg!("Mango: SettleBorrow DEPRECATED");
@@ -6396,9 +6396,9 @@ impl Processor {
                     program_id,
                     accounts,
                     asset_type,
-                    asset_index,
+                    asset_index as usize,
                     liab_type,
-                    liab_index,
+                    liab_index as usize,
                     max_liab_transfer,
                 )
             }
@@ -6412,7 +6412,7 @@ impl Processor {
             }
             MangoInstruction::ResolvePerpBankruptcy { liab_index, max_liab_transfer } => {
                 msg!("Mango: ResolvePerpBankruptcy");
-                Self::resolve_perp_bankruptcy(program_id, accounts, liab_index, max_liab_transfer)
+                Self::resolve_perp_bankruptcy(program_id, accounts, liab_index as usize, max_liab_transfer)
             }
             MangoInstruction::ResolveTokenBankruptcy { max_liab_transfer } => {
                 msg!("Mango: ResolveTokenBankruptcy");

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -191,7 +191,7 @@ impl PerpMarketInfo {
 #[repr(C)]
 pub struct MangoGroup {
     pub meta_data: MetaData,
-    pub num_oracles: usize, // incremented every time add_oracle is called
+    pub num_oracles: u64, // incremented every time add_oracle is called
 
     pub tokens: [TokenInfo; MAX_TOKENS],
     pub spot_markets: [SpotMarketInfo; MAX_PAIRS],
@@ -703,7 +703,7 @@ impl MangoCache {
         active_assets: &UserActiveAssets,
         now_ts: u64,
     ) -> MangoResult<()> {
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize {
             if active_assets.spot[i] || active_assets.perps[i] {
                 self.price_cache[i].check_valid(&mango_group, now_ts)?;
             }
@@ -741,7 +741,7 @@ impl UserActiveAssets {
     ) -> Self {
         let mut spot = [false; MAX_PAIRS];
         let mut perps = [false; MAX_PAIRS];
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize{
             spot[i] = !mango_group.spot_markets[i].is_empty()
                 && (mango_account.in_margin_basket[i]
                     || !mango_account.deposits[i].is_zero()
@@ -805,7 +805,7 @@ impl HealthCache {
         open_orders_ais: &[AccountInfo; MAX_PAIRS],
     ) -> MangoResult<()> {
         self.quote = mango_account.get_net(&mango_cache.root_bank_cache[QUOTE_INDEX], QUOTE_INDEX);
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize{
             if self.active_assets.spot[i] {
                 self.spot[i] = mango_account.get_spot_val(
                     &mango_cache.root_bank_cache[i],
@@ -839,7 +839,7 @@ impl HealthCache {
         open_orders: &[Option<T>],
     ) -> MangoResult<()> {
         self.quote = mango_account.get_net(&mango_cache.root_bank_cache[QUOTE_INDEX], QUOTE_INDEX);
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize{
             if self.active_assets.spot[i] {
                 self.spot[i] = mango_account.get_spot_val(
                     &mango_cache.root_bank_cache[i],
@@ -866,7 +866,7 @@ impl HealthCache {
             None => {
                 // apply weights, cache result, return health
                 let mut health = self.quote;
-                for i in 0..mango_group.num_oracles {
+                for i in 0..mango_group.num_oracles as usize {
                     let spot_market_info = &mango_group.spot_markets[i];
                     let perp_market_info = &mango_group.perp_markets[i];
 
@@ -924,7 +924,7 @@ impl HealthCache {
         } else {
             (self.quote, ZERO_I80F48)
         };
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize {
             let spot_market_info = &mango_group.spot_markets[i];
             let perp_market_info = &mango_group.perp_markets[i];
 
@@ -1446,7 +1446,7 @@ impl MangoAccount {
             return false;
         }
 
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize {
             if self.deposits[i] > DUST_THRESHOLD {
                 return false;
             }
@@ -1477,7 +1477,7 @@ impl MangoAccount {
             return false;
         }
 
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize {
             if self.borrows[i] > DUST_THRESHOLD {
                 return false;
             }
@@ -1510,7 +1510,7 @@ impl MangoAccount {
         packed_open_orders_ais: &'a [AccountInfo<'b>],
     ) -> MangoResult<Vec<Option<&'a AccountInfo<'b>>>> {
         let mut unpacked = vec![None; MAX_PAIRS];
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize {
             if self.in_margin_basket[i] {
                 unpacked[i] = Some(self.checked_unpack_open_orders_single(
                     mango_group,
@@ -1526,7 +1526,7 @@ impl MangoAccount {
         mango_group: &MangoGroup,
         open_orders_ais: &[AccountInfo; MAX_PAIRS],
     ) -> MangoResult {
-        for i in 0..mango_group.num_oracles {
+        for i in 0..mango_group.num_oracles as usize {
             if self.in_margin_basket[i] {
                 check_eq!(
                     open_orders_ais[i].key,

--- a/program/tests/program_test/cookies.rs
+++ b/program/tests/program_test/cookies.rs
@@ -218,7 +218,7 @@ impl MangoGroupCookie {
         test.cache_all_prices(
             mango_group,
             &self.address,
-            &mango_group.oracles[0..mango_group.num_oracles],
+            &mango_group.oracles[0..mango_group.num_oracles as usize],
         )
         .await;
 

--- a/program/tests/program_test/mod.rs
+++ b/program/tests/program_test/mod.rs
@@ -1889,9 +1889,9 @@ impl MangoProgramTest {
             &liqee_mango_account.spot_open_orders,
             &liqor_mango_account.spot_open_orders,
             asset_type,
-            asset_index,
+            asset_index as u64,
             liab_type,
-            liab_index,
+            liab_index as u64,
             max_liab_transfer,
         )
         .unwrap()];


### PR DESCRIPTION
## Problem
We are using wasm to reuse our rust logic in our client libraries. Wasm uses the `wasm32-unknown-unknown` target which is on 32 bit architecture.
Mango is using `usize` data type in many instruction and state structs, this is problematic for a few reasons.

`usize` docs:
> The pointer-sized unsigned integer type.
> The size of this primitive is how many bytes it takes to reference any location in memory. For example, on a 32 bit target, this is 4 bytes and on a 64 bit target, this is 8 bytes.

Mango code largely assumes usize is 8 bytes, which is expected with bpf and solana runtime, however wasm expects it to be 4 bytes, meaning it:
- can't build mango code
- incorrectly deserializes mango state
- incorrectly deserializes mango instructions

## Fix
This PR changes every `usize` type used in instruction or state structs to `u64`, which is the actual size of `usize` expected by the Mango program and clients, meaning this doesn't introduce any changes to the size of the ix or state data.

`u64` is converted to `usize` where it was used in logic before, this is poses no issue as the conversion is trivial because both `u64` and `usize` are the same size for the `bpf` target.
The only place where conversions are theoretically problematic is when converting from `u64` to `usize` for `wasm32` target, as the `u64` value might be larger than what can fit into `usize` (`u32`). However since any `usize` value is use only for indexing, the current possible values all fit into `u32`.
Additionally the problematic conversions are only possible for wasm compiled code, meaning they are not possible in the solana runtime.