### PR TITLE
allow passing in as many open orders as needed

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -133,6 +133,8 @@ pub enum MangoErrorCode {
         "MangoErrorCode::InvalidOrderInClosingMarket You may only have one open order at a time and it must be reducing position"
     )]
     InvalidOrderInClosingMarket,
+    #[error("MangoErrorCode::MissingOpenOrdersAccount")] // 40
+    MissingOpenOrdersAccount,
 
     #[error("MangoErrorCode::Default Check the source code for more info")] // 40
     Default = u32::MAX_VALUE,

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1273,8 +1273,8 @@ impl Processor {
         allow_borrow: bool,
     ) -> MangoResult<()> {
         const NUM_FIXED: usize = 10;
-        let accounts = array_ref![accounts, 0, NUM_FIXED + MAX_PAIRS];
-        let (fixed_ais, open_orders_ais) = array_refs![accounts, NUM_FIXED, MAX_PAIRS];
+        let fixed_ais = array_ref![accounts, 0, NUM_FIXED];
+        let open_orders_ais = &accounts[NUM_FIXED..];
         let [
             mango_group_ai,     // read
             mango_account_ai,   // write

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -802,7 +802,7 @@ impl HealthCache {
         mango_group: &MangoGroup,
         mango_cache: &MangoCache,
         mango_account: &MangoAccount,
-        open_orders_ais: &[AccountInfo; MAX_PAIRS],
+        open_orders_ais: &[AccountInfo],
     ) -> MangoResult<()> {
         self.quote = mango_account.get_net(&mango_cache.root_bank_cache[QUOTE_INDEX], QUOTE_INDEX);
         for i in 0..mango_group.num_oracles {
@@ -811,7 +811,7 @@ impl HealthCache {
                     &mango_cache.root_bank_cache[i],
                     mango_cache.price_cache[i].price,
                     i,
-                    &if *open_orders_ais[i].key == Pubkey::default() {
+                    &if mango_account.spot_open_orders[i] == Pubkey::default() {
                         None
                     } else {
                         Some(load_open_orders(&open_orders_ais[i])?)
@@ -1524,7 +1524,7 @@ impl MangoAccount {
     pub fn check_open_orders(
         &self,
         mango_group: &MangoGroup,
-        open_orders_ais: &[AccountInfo; MAX_PAIRS],
+        open_orders_ais: &[AccountInfo],
     ) -> MangoResult {
         for i in 0..mango_group.num_oracles {
             if self.in_margin_basket[i] {

--- a/program/tests/program_test/mod.rs
+++ b/program/tests/program_test/mod.rs
@@ -1760,7 +1760,7 @@ impl MangoProgramTest {
         let mango_program_id = self.mango_program_id;
         let mango_group = mango_group_cookie.mango_group;
         let mango_group_pk = mango_group_cookie.address;
-        let _mango_account = mango_group_cookie.mango_accounts[user_index].mango_account;
+        let mango_account = mango_group_cookie.mango_accounts[user_index].mango_account;
         let mango_account_pk = mango_group_cookie.mango_accounts[user_index].address;
 
         let delegate_user =

--- a/program/tests/program_test/mod.rs
+++ b/program/tests/program_test/mod.rs
@@ -1705,6 +1705,49 @@ impl MangoProgramTest {
     }
 
     #[allow(dead_code)]
+    pub async fn perform_withdraw_no_oo(
+        &mut self,
+        mango_group_cookie: &MangoGroupCookie,
+        user_index: usize,
+        mint_index: usize,
+        quantity: u64,
+        allow_borrow: bool,
+    ) -> Result<(), TransportError> {
+        let mango_program_id = self.mango_program_id;
+        let mango_group = mango_group_cookie.mango_group;
+        let mango_group_pk = mango_group_cookie.address;
+        let _mango_account = mango_group_cookie.mango_accounts[user_index].mango_account;
+        let mango_account_pk = mango_group_cookie.mango_accounts[user_index].address;
+
+        let user = Keypair::from_base58_string(&self.users[user_index].to_base58_string());
+        let user_token_account = self.with_user_token_account(user_index, mint_index);
+
+        let (signer_pk, _signer_nonce) =
+            create_signer_key_and_nonce(&mango_program_id, &mango_group_pk);
+
+        let (root_bank_pk, root_bank) = self.with_root_bank(&mango_group, mint_index).await;
+        let (node_bank_pk, node_bank) = self.with_node_bank(&root_bank, 0).await; // Note: not sure if nb_index is ever anything else than 0
+
+        let instructions = [withdraw(
+            &mango_program_id,
+            &mango_group_pk,
+            &mango_account_pk,
+            &user.pubkey(),
+            &mango_group.mango_cache,
+            &root_bank_pk,
+            &node_bank_pk,
+            &node_bank.vault,
+            &user_token_account,
+            &signer_pk,
+            &[],
+            quantity,
+            allow_borrow,
+        )
+        .unwrap()];
+        self.process_transaction(&instructions, Some(&[&user])).await
+    }
+
+    #[allow(dead_code)]
     pub async fn perform_withdraw_with_delegate(
         &mut self,
         mango_group_cookie: &MangoGroupCookie,
@@ -1717,7 +1760,7 @@ impl MangoProgramTest {
         let mango_program_id = self.mango_program_id;
         let mango_group = mango_group_cookie.mango_group;
         let mango_group_pk = mango_group_cookie.address;
-        let mango_account = mango_group_cookie.mango_accounts[user_index].mango_account;
+        let _mango_account = mango_group_cookie.mango_accounts[user_index].mango_account;
         let mango_account_pk = mango_group_cookie.mango_accounts[user_index].address;
 
         let delegate_user =

--- a/program/tests/program_test/scenarios.rs
+++ b/program/tests/program_test/scenarios.rs
@@ -55,6 +55,33 @@ pub async fn withdraw_scenario(
 }
 
 #[allow(dead_code)]
+pub async fn withdraw_scenario_no_oo(
+    test: &mut MangoProgramTest,
+    mango_group_cookie: &mut MangoGroupCookie,
+    withdraws: &Vec<(usize, usize, f64, bool)>,
+) -> Result<(), TransportError> {
+    mango_group_cookie.run_keeper(test).await;
+
+    for (user_index, mint_index, amount, allow_borrow) in withdraws {
+        let mint = test.with_mint(*mint_index);
+        let withdraw_amount = (*amount * mint.unit) as u64;
+        let result = test
+            .perform_withdraw_no_oo(
+                &mango_group_cookie,
+                *user_index,
+                *mint_index,
+                withdraw_amount,
+                *allow_borrow,
+            )
+            .await;
+        if result.is_err() {
+            return result;
+        }
+    }
+    Ok(())
+}
+
+#[allow(dead_code)]
 pub async fn withdraw_scenario_with_delegate(
     test: &mut MangoProgramTest,
     mango_group_cookie: &mut MangoGroupCookie,

--- a/program/tests/test_sanity.rs
+++ b/program/tests/test_sanity.rs
@@ -46,7 +46,7 @@ async fn test_vault_net_deposit_diff() {
     deposit_scenario(&mut test, &mut mango_group_cookie, &user_deposits).await;
 
     // Step 2: Make withdraws
-    withdraw_scenario(&mut test, &mut mango_group_cookie, &user_withdraws).await;
+    withdraw_scenario_no_oo(&mut test, &mut mango_group_cookie, &user_withdraws).await.unwrap();
 
     // === Assert ===
     mango_group_cookie.run_keeper(&mut test).await;

--- a/program/tests/test_spot_markets.rs
+++ b/program/tests/test_spot_markets.rs
@@ -123,6 +123,9 @@ async fn test_place_spot_order() {
     // Deposit amounts
     let user_deposits = vec![(user_index, test.quote_index, base_price)];
 
+    // Withdraw amounts
+    let user_withdraws = vec![(user_index, test.quote_index, base_price, false)];
+
     // Spot Orders
     let user_spot_orders =
         vec![(user_index, mint_index, serum_dex::matching::Side::Bid, base_size, base_price)];
@@ -154,6 +157,10 @@ async fn test_place_spot_order() {
     for expected_values in expected_values_vec {
         assert_user_spot_orders(&mut test, &mango_group_cookie, expected_values).await;
     }
+
+    withdraw_scenario_no_oo(&mut test, &mut mango_group_cookie, &user_withdraws)
+        .await
+        .expect_err("should not be able to withdraw");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Withdraw instruction size was too large for governance.
This change removes the requirement to pass default pks for spot open orders on withdraw, when the user doesn't have any.

