### PR TITLE
Add edit order instructions for spot and perp

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1066,7 +1066,7 @@ pub enum MangoInstruction {
         new_order: serum_dex::instruction::NewOrderInstructionV3,
     },
 
-    /// Replaces a perp order
+    /// Replaces a perp order, using the client_order_id
     /// Accounts expected by this instruction (9 + `NUM_IN_MARGIN_BASKET`):
     /// 0. `[]` mango_group_ai - MangoGroup
     /// 1. `[writable]` mango_account_ai - the MangoAccount of owner
@@ -1103,6 +1103,67 @@ pub enum MangoInstruction {
         expiry_timestamp: u64,
 
         /// Client order id of order to replace
+        client_order_id: u64,
+
+        /// Expected quantity remaining on the order to be replaced
+        cancel_order_size: i64,
+
+        side: Side,
+
+        /// Can be 0 -> LIMIT, 1 -> IOC, 2 -> PostOnly, 3 -> Market, 4 -> PostOnlySlide
+        order_type: OrderType,
+
+        reduce_only: bool,
+
+        /// Maximum number of orders from the book to fill.
+        ///
+        /// Use this to limit compute used during order matching.
+        /// When the limit is reached, processing stops and the instruction succeeds.
+        limit: u8,
+
+        invalid_id_ok: bool,
+    },
+
+    /// Replaces a perp order, using the order_id
+    /// Accounts expected by this instruction (9 + `NUM_IN_MARGIN_BASKET`):
+    /// 0. `[]` mango_group_ai - MangoGroup
+    /// 1. `[writable]` mango_account_ai - the MangoAccount of owner
+    /// 2. `[signer]` owner_ai - owner of MangoAccount
+    /// 3. `[]` mango_cache_ai - MangoCache for this MangoGroup
+    /// 4. `[writable]` perp_market_ai
+    /// 5. `[writable]` bids_ai - bids account for this PerpMarket
+    /// 6. `[writable]` asks_ai - asks account for this PerpMarket
+    /// 7. `[writable]` event_queue_ai - EventQueue for this PerpMarket
+    /// 8. `[writable]` referrer_mango_account_ai - referrer's mango account;
+    ///                 pass in mango_account_ai as duplicate if you don't have a referrer
+    /// 9..9 + NUM_IN_MARGIN_BASKET `[]` open_orders_ais - pass in open orders in margin basket
+    EditPerpOrder {
+        /// Id of the order to replace
+        cancel_order_id: i128,
+
+        /// Price in quote lots per base lots.
+        ///
+        /// Effect is based on order type, it's usually
+        /// - fill orders on the book up to this price or
+        /// - place an order on the book at this price.
+        ///
+        /// Ignored for Market orders and potentially adjusted for PostOnlySlide orders.
+        price: i64,
+
+        /// Max base lots to buy/sell.
+        max_base_quantity: i64,
+
+        /// Max quote lots to pay/receive (not taking fees into account).
+        max_quote_quantity: i64,
+
+        /// Timestamp of when order expires
+        ///
+        /// Send 0 if you want the order to never expire.
+        /// Timestamps in the past mean the instruction is skipped.
+        /// Timestamps in the future are reduced to now + 255s.
+        expiry_timestamp: u64,
+
+        /// Client order id of the updated order
         client_order_id: u64,
 
         /// Expected quantity remaining on the order to be replaced
@@ -1646,6 +1707,37 @@ impl MangoInstruction {
                     invalid_id_ok,
                 ) = array_refs![data_arr, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1];
                 MangoInstruction::EditPerpOrderByClientId {
+                    price: i64::from_le_bytes(*price),
+                    max_base_quantity: i64::from_le_bytes(*max_base_quantity),
+                    max_quote_quantity: i64::from_le_bytes(*max_quote_quantity),
+                    expiry_timestamp: u64::from_le_bytes(*expiry_timestamp),
+                    client_order_id: u64::from_le_bytes(*client_order_id),
+                    cancel_order_size: i64::from_le_bytes(*cancel_order_size),
+                    side: Side::try_from_primitive(side[0]).ok()?,
+                    order_type: OrderType::try_from_primitive(order_type[0]).ok()?,
+                    reduce_only: reduce_only[0] != 0,
+                    limit: u8::from_le_bytes(*limit),
+                    invalid_id_ok: invalid_id_ok[0] != 0,
+                }
+            }
+            68 => {
+                let data_arr = array_ref![data, 0, 69];
+                let (
+                    cancel_order_id,
+                    price,
+                    max_base_quantity,
+                    max_quote_quantity,
+                    expiry_timestamp,
+                    client_order_id,
+                    cancel_order_size,
+                    side,
+                    order_type,
+                    reduce_only,
+                    limit,
+                    invalid_id_ok,
+                ) = array_refs![data_arr, 16, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1];
+                MangoInstruction::EditPerpOrder {
+                    cancel_order_id: i128::from_le_bytes(*cancel_order_id),
                     price: i64::from_le_bytes(*price),
                     max_base_quantity: i64::from_le_bytes(*max_base_quantity),
                     max_quote_quantity: i64::from_le_bytes(*max_quote_quantity),
@@ -3189,54 +3281,60 @@ pub fn edit_perp_order_by_client_id(
     Ok(Instruction { program_id: *program_id, accounts, data })
 }
 
-// pub fn edit_perp_order(
-//     program_id: &Pubkey,
-//     mango_group_pk: &Pubkey,
-//     mango_account_pk: &Pubkey,
-//     owner_pk: &Pubkey,
-//     mango_cache_pk: &Pubkey,
-//     perp_market_pk: &Pubkey,
-//     bids_pk: &Pubkey,
-//     asks_pk: &Pubkey,
-//     event_queue_pk: &Pubkey,
-//     referrer_mango_account_pk: Option<&Pubkey>,
-//     open_orders_pks: &[Pubkey],
-//     side: Side,
-//     price: i64,
-//     max_base_quantity: i64,
-//     max_quote_quantity: i64,
-//     client_order_id: u64,
-//     order_type: OrderType,
-//     reduce_only: bool,
-//     expiry_timestamp: Option<u64>, // Send 0 if you want to ignore time in force
-//     limit: u8,                     // maximum number of FillEvents before terminating
-// ) -> Result<Instruction, ProgramError> {
-//     let mut accounts = vec![
-//         AccountMeta::new_readonly(*mango_group_pk, false),
-//         AccountMeta::new(*mango_account_pk, false),
-//         AccountMeta::new_readonly(*owner_pk, true),
-//         AccountMeta::new_readonly(*mango_cache_pk, false),
-//         AccountMeta::new(*perp_market_pk, false),
-//         AccountMeta::new(*bids_pk, false),
-//         AccountMeta::new(*asks_pk, false),
-//         AccountMeta::new(*event_queue_pk, false),
-//         AccountMeta::new(*referrer_mango_account_pk.unwrap_or(mango_account_pk), false),
-//     ];
+pub fn edit_perp_order(
+    program_id: &Pubkey,
+    mango_group_pk: &Pubkey,
+    mango_account_pk: &Pubkey,
+    owner_pk: &Pubkey,
+    mango_cache_pk: &Pubkey,
+    perp_market_pk: &Pubkey,
+    bids_pk: &Pubkey,
+    asks_pk: &Pubkey,
+    event_queue_pk: &Pubkey,
+    referrer_mango_account_pk: Option<&Pubkey>,
+    open_orders_pks: &[Pubkey],
+    cancel_order_id: i128,
+    price: i64,
+    max_base_quantity: i64,
+    max_quote_quantity: i64,
+    expiry_timestamp: u64,
+    client_order_id: u64,
+    cancel_order_size: i64,
+    side: Side,
+    order_type: OrderType,
+    reduce_only: bool,
+    limit: u8,
+    invalid_id_ok: bool,
+) -> Result<Instruction, ProgramError> {
+    let mut accounts = vec![
+        AccountMeta::new_readonly(*mango_group_pk, false),
+        AccountMeta::new(*mango_account_pk, false),
+        AccountMeta::new_readonly(*owner_pk, true),
+        AccountMeta::new_readonly(*mango_cache_pk, false),
+        AccountMeta::new(*perp_market_pk, false),
+        AccountMeta::new(*bids_pk, false),
+        AccountMeta::new(*asks_pk, false),
+        AccountMeta::new(*event_queue_pk, false),
+        AccountMeta::new(*referrer_mango_account_pk.unwrap_or(mango_account_pk), false),
+    ];
 
-//     accounts.extend(open_orders_pks.iter().map(|pk| AccountMeta::new_readonly(*pk, false)));
+    accounts.extend(open_orders_pks.iter().map(|pk| AccountMeta::new_readonly(*pk, false)));
 
-//     let instr = MangoInstruction::EditPerpOrderByClientId {
-//         side,
-//         price,
-//         max_base_quantity,
-//         max_quote_quantity,
-//         client_order_id,
-//         order_type,
-//         reduce_only,
-//         expiry_timestamp: expiry_timestamp.unwrap_or(0),
-//         limit,
-//     };
-//     let data = instr.pack();
+    let instr = MangoInstruction::EditPerpOrder {
+        cancel_order_id,
+        price,
+        max_base_quantity,
+        max_quote_quantity,
+        expiry_timestamp,
+        client_order_id,
+        cancel_order_size,
+        side,
+        order_type,
+        reduce_only,
+        limit,
+        invalid_id_ok,
+    };
+    let data = instr.pack();
 
-//     Ok(Instruction { program_id: *program_id, accounts, data })
-// }
+    Ok(Instruction { program_id: *program_id, accounts, data })
+}

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -2403,7 +2403,7 @@ impl Processor {
             }
         }
 
-        check!(new_order.side == cancel_order.side, MangoErrorCode::Default);
+        check!(new_order.side == cancel_order.side, MangoErrorCode::Default)?;
 
         // if cancel order has been partially filled, reduce the new order size to accommodate
         let filled_amount = expected_cancel_size.checked_sub(remaining_cancel_size).unwrap();
@@ -2448,7 +2448,7 @@ impl Processor {
                 signer_ai.clone(),
                 dex_event_queue_ai.clone(),
             ];
-            Self::cancel_spot_order(program_id, &cancel_accounts[..], cancel_data).unwrap();
+            Self::cancel_spot_order(program_id, &cancel_accounts[..], cancel_data)?;
         }
 
         {
@@ -2472,11 +2472,117 @@ impl Processor {
                 dex_signer_ai.clone(),
                 token_prog_ai.clone(),
             ];
-            Self::settle_funds(program_id, &settle_accounts[..]).unwrap();
+            Self::settle_funds(program_id, &settle_accounts[..])?;
         }
 
         {
-            Self::place_spot_order2(program_id, accounts, new_order).unwrap();
+            Self::place_spot_order2(program_id, accounts, new_order)?;
+        }
+
+        Ok(())
+    }
+
+    #[inline(never)]
+    pub fn edit_perp_order_by_client_id(
+        program_id: &Pubkey,
+        accounts: &[AccountInfo],
+        price: i64,
+        mut max_base_quantity: i64,
+        max_quote_quantity: i64,
+        expiry_timestamp: u64,
+        client_order_id: u64,
+        expected_cancel_size: i64,
+        side: Side,
+        order_type: OrderType,
+        reduce_only: bool,
+        limit: u8,
+    ) -> MangoResult {
+        const NUM_FIXED: usize = 9;
+        let (fixed_ais, _packed_open_orders_ais) = array_refs![accounts, NUM_FIXED; ..;];
+        let [
+            mango_group_ai,             // read
+            mango_account_ai,           // write
+            owner_ai,                   // read, signer
+            _mango_cache_ai,             // read
+            perp_market_ai,             // write
+            bids_ai,                    // write
+            asks_ai,                    // write
+            _event_queue_ai,             // write
+            _referrer_mango_account_ai,  // write
+        ] = fixed_ais;
+
+        {
+            let mango_group = MangoGroup::load_checked(mango_group_ai, program_id)?;
+
+            let mango_account =
+                MangoAccount::load_checked(mango_account_ai, program_id, mango_group_ai.key)?;
+            check!(!mango_account.is_bankrupt, MangoErrorCode::Bankrupt)?;
+            check!(owner_ai.is_signer, MangoErrorCode::SignerNecessary)?;
+            check!(
+                &mango_account.owner == owner_ai.key || &mango_account.delegate == owner_ai.key,
+                MangoErrorCode::InvalidOwner
+            )?;
+
+            let perp_market =
+                PerpMarket::load_checked(perp_market_ai, program_id, mango_group_ai.key)?;
+
+            let market_index = mango_group.find_perp_market_index(perp_market_ai.key).unwrap();
+
+            let book = Book::load_checked(program_id, bids_ai, asks_ai, &perp_market)?;
+
+            let (order_id, cancel_side) = mango_account
+                .find_order_with_client_id(market_index, client_order_id)
+                .ok_or(throw_err!(MangoErrorCode::ClientIdNotFound))?;
+
+            let book_order = book.get_order(order_id, side)?;
+            check!(cancel_side == side, MangoErrorCode::Default)?;
+            if book_order.quantity < 0
+                || expected_cancel_size < 0
+                || book_order.quantity > expected_cancel_size
+            {
+                throw_err!(MangoErrorCode::Default);
+            }
+
+            let filled_amount = expected_cancel_size.checked_sub(book_order.quantity).unwrap();
+            if filled_amount > 0 {
+                let new_max_base = max_base_quantity.checked_sub(filled_amount).unwrap();
+                if new_max_base < 0 {
+                    throw_err!(MangoErrorCode::Default);
+                }
+                max_base_quantity = new_max_base;
+            };
+        }
+
+        {
+            let cancel_accounts = [
+                mango_group_ai.clone(),
+                mango_account_ai.clone(),
+                owner_ai.clone(),
+                perp_market_ai.clone(),
+                bids_ai.clone(),
+                asks_ai.clone(),
+            ];
+            Self::cancel_perp_order_by_client_id(
+                program_id,
+                &cancel_accounts[..],
+                client_order_id,
+            )?;
+        }
+
+        {
+            Self::place_perp_order2(
+                program_id,
+                accounts,
+                side,
+                price,
+                max_base_quantity,
+                max_quote_quantity,
+                client_order_id,
+                order_type,
+                reduce_only,
+                expiry_timestamp,
+                limit,
+            )?
         }
 
         Ok(())
@@ -7012,22 +7118,46 @@ impl Processor {
                     cancel_order_size,
                     new_order,
                 )
-            } // MangoInstruction::EditPerpOrderByClientId { client_order_id, invalid_id_ok } => {
-              //     msg!("Mango: EditPerpOrderByClientId client_order_id={}", client_order_id);
-              //     let result =
-              //         Self::edit_perp_order_by_client_id(program_id, accounts, client_order_id);
-              //     if invalid_id_ok {
-              //         if let Err(MangoError::MangoErrorCode { mango_error_code, .. }) = result {
-              //             if mango_error_code == MangoErrorCode::InvalidOrderId
-              //                 || mango_error_code == MangoErrorCode::ClientIdNotFound
-              //             {
-              //                 return Ok(());
-              //             }
-              //         }
-              //     }
-              //     result
-              // }
-              // MangoInstruction::EditPerpOrder { order_id, invalid_id_ok } => {
+            }
+            MangoInstruction::EditPerpOrderByClientId {
+                price,
+                max_base_quantity,
+                max_quote_quantity,
+                expiry_timestamp,
+                client_order_id,
+                cancel_order_size,
+                side,
+                order_type,
+                reduce_only,
+                limit,
+                invalid_id_ok,
+            } => {
+                msg!("Mango: EditPerpOrderByClientId client_order_id={}", client_order_id);
+                let result = Self::edit_perp_order_by_client_id(
+                    program_id,
+                    accounts,
+                    price,
+                    max_base_quantity,
+                    max_quote_quantity,
+                    expiry_timestamp,
+                    client_order_id,
+                    cancel_order_size,
+                    side,
+                    order_type,
+                    reduce_only,
+                    limit,
+                );
+                if invalid_id_ok {
+                    if let Err(MangoError::MangoErrorCode { mango_error_code, .. }) = result {
+                        if mango_error_code == MangoErrorCode::InvalidOrderId
+                            || mango_error_code == MangoErrorCode::ClientIdNotFound
+                        {
+                            return Ok(());
+                        }
+                    }
+                }
+                result
+            } // MangoInstruction::EditPerpOrder { order_id, invalid_id_ok } => {
               //     // TODO OPT this log may cost too much compute
               //     msg!("Mango: EditPerpOrder order_id={}", order_id);
               //     let result = Self::edit_perp_order(program_id, accounts, order_id);

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -2403,6 +2403,8 @@ impl Processor {
             }
         }
 
+        check!(expected_cancel_size > 0, MangoErrorCode::Default)?;
+        check!(remaining_cancel_size > 0, MangoErrorCode::Default)?;
         check!(new_order.side == cancel_order.side, MangoErrorCode::Default)?;
 
         // if cancel order has been partially filled, reduce the new order size to accommodate
@@ -2536,8 +2538,8 @@ impl Processor {
 
             let book_order = book.get_order(order_id, side)?;
             check!(cancel_side == side, MangoErrorCode::Default)?;
-            if book_order.quantity < 0
-                || expected_cancel_size < 0
+            if book_order.quantity <= 0
+                || expected_cancel_size <= 0
                 || book_order.quantity > expected_cancel_size
             {
                 throw_err!(MangoErrorCode::Default);
@@ -2642,8 +2644,8 @@ impl Processor {
 
             let book_order = book.get_order(cancel_order_id, side)?;
             check!(cancel_side == side, MangoErrorCode::Default)?;
-            if book_order.quantity < 0
-                || expected_cancel_size < 0
+            if book_order.quantity <= 0
+                || expected_cancel_size <= 0
                 || book_order.quantity > expected_cancel_size
             {
                 throw_err!(MangoErrorCode::Default);

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -2312,6 +2312,235 @@ impl Processor {
     }
 
     #[inline(never)]
+    fn edit_spot_order(
+        program_id: &Pubkey,
+        accounts: &[AccountInfo],
+        cancel_data: Vec<u8>,
+        new_order: serum_dex::instruction::NewOrderInstructionV3,
+    ) -> MangoResult<()> {
+        const NUM_FIXED: usize = 22;
+        let (fixed_ais, packed_open_orders_ais) = array_refs![accounts, NUM_FIXED; ..;];
+        let [
+            mango_group_ai,         // read
+            mango_account_ai,       // write
+            owner_ai,               // read & signer
+            mango_cache_ai,         // read
+            dex_prog_ai,            // read
+            spot_market_ai,         // write
+            bids_ai,                // write
+            asks_ai,                // write
+            dex_request_queue_ai,   // write
+            dex_event_queue_ai,     // write
+            dex_base_ai,            // write
+            dex_quote_ai,           // write
+            base_root_bank_ai,      // read
+            base_node_bank_ai,      // write
+            base_vault_ai,          // write
+            quote_root_bank_ai,     // read
+            quote_node_bank_ai,     // write
+            quote_vault_ai,         // write
+            token_prog_ai,          // read
+            signer_ai,              // read
+            dex_signer_ai,          // read
+            msrm_or_srm_vault_ai,   // read
+        ] = fixed_ais;
+
+        // TODO: make sure health + orders are correct, etc.
+
+        
+        let mango_group = MangoGroup::load_checked(mango_group_ai, program_id)?;
+        check_eq!(token_prog_ai.key, &spl_token::ID, MangoErrorCode::InvalidProgramId)?;
+        check_eq!(dex_prog_ai.key, &mango_group.dex_program_id, MangoErrorCode::InvalidProgramId)?;
+        check!(signer_ai.key == &mango_group.signer_key, MangoErrorCode::InvalidSignerKey)?;
+
+        let mut mango_account =
+            MangoAccount::load_mut_checked(mango_account_ai, program_id, mango_group_ai.key)?;
+        check!(
+            &mango_account.owner == owner_ai.key || &mango_account.delegate == owner_ai.key,
+            MangoErrorCode::InvalidOwner
+        )?;
+        check!(owner_ai.is_signer, MangoErrorCode::InvalidSignerKey)?;
+        check!(!mango_account.is_bankrupt, MangoErrorCode::Bankrupt)?;
+        let mut open_orders_ais =
+            mango_account.checked_unpack_open_orders(&mango_group, packed_open_orders_ais)?;
+        let market_index = mango_group
+            .find_spot_market_index(spot_market_ai.key)
+            .ok_or(throw_err!(MangoErrorCode::InvalidMarket))?;
+
+        check!(
+            &mango_group.tokens[market_index].root_bank == base_root_bank_ai.key,
+            MangoErrorCode::InvalidRootBank
+        )?;
+        let base_root_bank = RootBank::load_checked(base_root_bank_ai, program_id)?;
+
+        let market_open_orders_ai = open_orders_ais[market_index].unwrap();
+
+        let order_side = new_order.side;
+        let vault_ai = match order_side {
+            serum_dex::matching::Side::Bid => quote_vault_ai,
+            serum_dex::matching::Side::Ask => base_vault_ai,
+        };
+        let signers_seeds = gen_signer_seeds(&mango_group.signer_nonce, mango_group_ai.key);
+
+
+        // TODO:  make sure the size is correct
+        
+
+        msg!("invoke cancel");
+        invoke_cancel_order(
+            dex_prog_ai,
+            spot_market_ai,
+            bids_ai,
+            asks_ai,
+            market_open_orders_ai,
+            signer_ai,
+            dex_event_queue_ai,
+            cancel_data,
+            &[&signers_seeds],
+        )?;
+
+        msg!("invoke new order");
+        invoke_new_order(
+            dex_prog_ai,
+            spot_market_ai,
+            &market_open_orders_ai,
+            dex_request_queue_ai,
+            dex_event_queue_ai,
+            bids_ai,
+            asks_ai,
+            vault_ai,
+            signer_ai,
+            dex_base_ai,
+            dex_quote_ai,
+            token_prog_ai,
+            msrm_or_srm_vault_ai,
+            &[&signers_seeds],
+            new_order,
+        )?;
+
+
+
+        msg!("invoke settle");
+
+        let (pre_base, pre_quote) = {
+            let open_orders = load_open_orders(market_open_orders_ai)?;
+            (
+                open_orders.native_coin_free,
+                open_orders.native_pc_free + open_orders.referrer_rebates_accrued,
+            )
+        };
+
+        if pre_base == 0 && pre_quote == 0 {
+            // margin basket may be in an invalid state; correct it before returning
+            let open_orders = load_open_orders(market_open_orders_ai)?;
+            mango_account.update_basket(market_index, &open_orders)?;
+            return Ok(());
+        }
+
+        // Settle funds for this market
+        invoke_settle_funds(
+            dex_prog_ai,
+            spot_market_ai,
+            market_open_orders_ai,
+            signer_ai,
+            dex_base_ai,
+            dex_quote_ai,
+            base_vault_ai,
+            quote_vault_ai,
+            dex_signer_ai,
+            token_prog_ai,
+            &[&signers_seeds],
+        )?;
+
+        
+        // The whole settle balances?? From cancel_all_orders
+
+        let (post_base, post_quote) = {
+            let open_orders = load_open_orders(market_open_orders_ai)?;
+            mango_account.update_basket(market_index, &open_orders)?;
+            mango_emit_stack::<_, 256>(OpenOrdersBalanceLog {
+                mango_group: *mango_group_ai.key,
+                mango_account: *mango_account_ai.key,
+                market_index: market_index as u64,
+                base_total: open_orders.native_coin_total,
+                base_free: open_orders.native_coin_free,
+                quote_total: open_orders.native_pc_total,
+                quote_free: open_orders.native_pc_free,
+                referrer_rebates_accrued: open_orders.referrer_rebates_accrued,
+            });
+
+            (
+                open_orders.native_coin_free,
+                open_orders.native_pc_free + open_orders.referrer_rebates_accrued,
+            )
+        };
+
+        check!(post_base <= pre_base, MangoErrorCode::Default)?;
+        check!(post_quote <= pre_quote, MangoErrorCode::Default)?;
+
+        // Update balances from settling funds
+        let base_change = I80F48::from_num(pre_base - post_base);
+        let quote_change = I80F48::from_num(pre_quote - post_quote);
+
+        let mango_cache = MangoCache::load_checked(mango_cache_ai, program_id, &mango_group)?;
+        let clock = Clock::get()?;
+        let now_ts = clock.unix_timestamp as u64;
+
+        mango_cache.root_bank_cache[market_index].check_valid(&mango_group, now_ts)?;
+        mango_cache.root_bank_cache[QUOTE_INDEX].check_valid(&mango_group, now_ts)?;
+
+        check_eq!(
+            &mango_group.tokens[market_index].root_bank,
+            base_root_bank_ai.key,
+            MangoErrorCode::InvalidRootBank
+        )?;
+        let base_root_bank = RootBank::load_checked(base_root_bank_ai, program_id)?;
+
+        check!(
+            base_root_bank.node_banks.contains(base_node_bank_ai.key),
+            MangoErrorCode::InvalidNodeBank
+        )?;
+        let mut base_node_bank = NodeBank::load_mut_checked(base_node_bank_ai, program_id)?;
+        check_eq!(&base_node_bank.vault, base_vault_ai.key, MangoErrorCode::InvalidVault)?;
+
+        check_eq!(
+            &mango_group.tokens[QUOTE_INDEX].root_bank,
+            quote_root_bank_ai.key,
+            MangoErrorCode::InvalidRootBank
+        )?;
+        let quote_root_bank = RootBank::load_checked(quote_root_bank_ai, program_id)?;
+
+        check!(
+            quote_root_bank.node_banks.contains(quote_node_bank_ai.key),
+            MangoErrorCode::InvalidNodeBank
+        )?;
+        let mut quote_node_bank = NodeBank::load_mut_checked(quote_node_bank_ai, program_id)?;
+        check_eq!(&quote_node_bank.vault, quote_vault_ai.key, MangoErrorCode::InvalidVault)?;
+
+        checked_change_net(
+            &mango_cache.root_bank_cache[market_index],
+            &mut base_node_bank,
+            &mut mango_account,
+            mango_account_ai.key,
+            market_index,
+            base_change,
+        )?;
+        checked_change_net(
+            &mango_cache.root_bank_cache[QUOTE_INDEX],
+            &mut quote_node_bank,
+            &mut mango_account,
+            mango_account_ai.key,
+            QUOTE_INDEX,
+            quote_change,
+        )?;
+
+
+        // TODO: health adjustments
+
+        Ok(())
+    }
+
+    #[inline(never)]
     fn settle_funds(program_id: &Pubkey, accounts: &[AccountInfo]) -> MangoResult {
         const NUM_FIXED: usize = 18;
         let accounts = array_ref![accounts, 0, NUM_FIXED];
@@ -6832,6 +7061,40 @@ impl Processor {
                 msg!("Mango: CancelAllSpotOrders");
                 Self::cancel_all_spot_orders(program_id, accounts, limit)
             }
+            MangoInstruction::EditSpotOrder { cancel_order, new_order } => {
+                msg!("Mango: EditSpotOrder");
+                let cancel_data = serum_dex::instruction::MarketInstruction::CancelOrderV2(cancel_order).pack();
+                Self::edit_spot_order(program_id, accounts, cancel_data,  new_order)
+            } 
+            
+            // MangoInstruction::EditPerpOrderByClientId { client_order_id, invalid_id_ok } => {
+              //     msg!("Mango: EditPerpOrderByClientId client_order_id={}", client_order_id);
+              //     let result =
+              //         Self::edit_perp_order_by_client_id(program_id, accounts, client_order_id);
+              //     if invalid_id_ok {
+              //         if let Err(MangoError::MangoErrorCode { mango_error_code, .. }) = result {
+              //             if mango_error_code == MangoErrorCode::InvalidOrderId
+              //                 || mango_error_code == MangoErrorCode::ClientIdNotFound
+              //             {
+              //                 return Ok(());
+              //             }
+              //         }
+              //     }
+              //     result
+              // }
+              // MangoInstruction::EditPerpOrder { order_id, invalid_id_ok } => {
+              //     // TODO OPT this log may cost too much compute
+              //     msg!("Mango: EditPerpOrder order_id={}", order_id);
+              //     let result = Self::edit_perp_order(program_id, accounts, order_id);
+              //     if invalid_id_ok {
+              //         if let Err(MangoError::MangoErrorCode { mango_error_code, .. }) = result {
+              //             if mango_error_code == MangoErrorCode::InvalidOrderId {
+              //                 return Ok(());
+              //             }
+              //         }
+              //     }
+              //     result
+              // }
         }
     }
 }

--- a/program/tests/program_test/cookies.rs
+++ b/program/tests/program_test/cookies.rs
@@ -637,6 +637,7 @@ impl SpotMarketCookie {
         size: f64,
         price: f64,
         cancel_order_id: u128,
+        cancel_order_size: u64,
     ) {
         let limit_price = test.price_number_to_lots(&self.mint, price);
         let max_coin_qty = test.base_size_number_to_lots(&self.mint, size);
@@ -647,13 +648,11 @@ impl SpotMarketCookie {
             serum_dex::matching::Side::Ask => std::u64::MAX,
         };
 
-        let cancel_order = serum_dex::instruction::CancelOrderInstructionV2 {
-            side, 
-            order_id: cancel_order_id,
-        };
+        let cancel_order =
+            serum_dex::instruction::CancelOrderInstructionV2 { side, order_id: cancel_order_id };
 
         let new_order = serum_dex::instruction::NewOrderInstructionV3 {
-            side, 
+            side,
             limit_price: NonZeroU64::new(limit_price).unwrap(),
             max_coin_qty: NonZeroU64::new(max_coin_qty).unwrap(),
             max_native_pc_qty_including_fees: NonZeroU64::new(max_native_pc_qty_including_fees)
@@ -665,7 +664,15 @@ impl SpotMarketCookie {
             max_ts: i64::MAX,
         };
 
-        test.edit_spot_order(&mango_group_cookie, self, user_index, cancel_order, new_order).await;
+        test.edit_spot_order(
+            &mango_group_cookie,
+            self,
+            user_index,
+            cancel_order,
+            cancel_order_size,
+            new_order,
+        )
+        .await;
 
         mango_group_cookie.mango_accounts[user_index].mango_account = test
             .load_account::<MangoAccount>(mango_group_cookie.mango_accounts[user_index].address)

--- a/program/tests/program_test/mod.rs
+++ b/program/tests/program_test/mod.rs
@@ -2063,6 +2063,68 @@ impl MangoProgramTest {
 
         self.process_transaction(&instructions, Some(&signers)).await.unwrap();
     }
+
+    #[allow(dead_code)]
+    pub async fn edit_perp_order(
+        &mut self,
+        mango_group_cookie: &MangoGroupCookie,
+        perp_market_cookie: &PerpMarketCookie,
+        user_index: usize,
+        order_price: i64,
+        order_base_size: i64,
+        order_quote_size: i64,
+        expiry_timestamp: u64,
+        client_order_id: u64,
+        expected_cancel_size: i64,
+        side: Side,
+        order_type: OrderType,
+        reduce_only: bool,
+        limit: u8,
+        invalid_id_ok: bool,
+    ) {
+        let mango_program_id = self.mango_program_id;
+        let mango_group = mango_group_cookie.mango_group;
+        let mango_group_pk = mango_group_cookie.address;
+        let mango_account = mango_group_cookie.mango_accounts[user_index].mango_account;
+        let mango_account_pk = mango_group_cookie.mango_accounts[user_index].address;
+        let perp_market = perp_market_cookie.perp_market;
+        let perp_market_pk = perp_market_cookie.address;
+
+        let user = Keypair::from_base58_string(&self.users[user_index].to_base58_string());
+        let open_orders_pks: Vec<Pubkey> = mango_account
+            .spot_open_orders
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &pk)| if mango_account.in_margin_basket[i] { Some(pk) } else { None })
+            .collect();
+
+        let instructions = [mango::instruction::edit_perp_order_by_client_id(
+            &mango_program_id,
+            &mango_group_pk,
+            &mango_account_pk,
+            &user.pubkey(),
+            &mango_group.mango_cache,
+            &perp_market_pk,
+            &perp_market.bids,
+            &perp_market.asks,
+            &perp_market.event_queue,
+            None,
+            &open_orders_pks,
+            order_price,
+            order_base_size,
+            order_quote_size,
+            expiry_timestamp,
+            client_order_id,
+            expected_cancel_size,
+            side,
+            order_type,
+            reduce_only,
+            limit,
+            invalid_id_ok,
+        )
+        .unwrap()];
+        self.process_transaction(&instructions, Some(&[&user])).await.unwrap();
+    }
 }
 
 fn process_serum_instruction(

--- a/program/tests/program_test/mod.rs
+++ b/program/tests/program_test/mod.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 
 use bincode::deserialize;
 use fixed::types::I80F48;
-use serum_dex::instruction::NewOrderInstructionV3;
+use serum_dex::{instruction::{CancelOrderInstructionV2, NewOrderInstructionV3}, state::OpenOrders};
 use solana_program::entrypoint::ProgramResult;
 use solana_program::{
     account_info::AccountInfo,
@@ -455,6 +455,29 @@ impl MangoProgramTest {
         let open_orders = load_open_orders(&acc).unwrap();
         let (quote_free, quote_locked, base_free, base_locked) = split_open_orders(&open_orders);
         return (quote_free, quote_locked, base_free, base_locked);
+    }
+
+    #[allow(dead_code)]
+    pub async fn get_oo(
+        &mut self,
+        mango_group_cookie: &MangoGroupCookie,
+        user_index: usize,
+        mint_index: usize,
+    ) -> OpenOrders {
+        let mango_account = mango_group_cookie.mango_accounts[user_index].mango_account;
+        let mut oo = self.get_account(mango_account.spot_open_orders[0]).await;
+        let clock = self.get_clock().await;
+        let acc = solana_program::account_info::AccountInfo::new(
+            &mango_account.spot_open_orders[mint_index],
+            false,
+            false,
+            &mut oo.lamports,
+            &mut oo.data,
+            &mango_group_cookie.mango_accounts[user_index].address,
+            false,
+            clock.epoch,
+        );
+        return *load_open_orders(&acc).unwrap();
     }
 
     #[allow(dead_code)]
@@ -1946,6 +1969,94 @@ impl MangoProgramTest {
 
         mango_group_cookie.mango_accounts[liqor_index].mango_account =
             self.load_account::<MangoAccount>(liqor_mango_account_pk).await;
+    }
+
+#[allow(dead_code)]
+    pub async fn edit_spot_order(
+        &mut self,
+        mango_group_cookie: &MangoGroupCookie,
+        spot_market_cookie: &SpotMarketCookie,
+        user_index: usize,
+        cancel_order: CancelOrderInstructionV2,
+        new_order: NewOrderInstructionV3,
+    ) {
+        let mango_program_id = self.mango_program_id;
+        let serum_program_id = self.serum_program_id;
+        let mango_group = mango_group_cookie.mango_group;
+        let mango_group_pk = mango_group_cookie.address;
+        let mango_account = mango_group_cookie.mango_accounts[user_index].mango_account;
+        let mango_account_pk = mango_group_cookie.mango_accounts[user_index].address;
+        let mint_index = spot_market_cookie.mint.index;
+
+        let user = Keypair::from_base58_string(&self.users[user_index].to_base58_string());
+
+        let (signer_pk, _signer_nonce) =
+            create_signer_key_and_nonce(&mango_program_id, &mango_group_pk);
+
+        let (mint_root_bank_pk, mint_root_bank) =
+            self.with_root_bank(&mango_group, mint_index).await;
+        let (mint_node_bank_pk, mint_node_bank) = self.with_node_bank(&mint_root_bank, 0).await;
+        let (quote_root_bank_pk, quote_root_bank) =
+            self.with_root_bank(&mango_group, self.quote_index).await;
+        let (quote_node_bank_pk, quote_node_bank) = self.with_node_bank(&quote_root_bank, 0).await;
+
+        // Only pass in open orders if in margin basket or current market index, and
+        // the only writable account should be OpenOrders for current market index
+        let mut open_orders_pks = Vec::new();
+        for x in 0..mango_account.spot_open_orders.len() {
+            if x == mint_index && mango_account.spot_open_orders[x] == Pubkey::default() {
+                open_orders_pks.push(
+                    self.create_spot_open_orders(
+                        &mango_group_pk,
+                        &mango_group,
+                        &mango_account_pk,
+                        user_index,
+                        x,
+                        None,
+                    )
+                    .await,
+                );
+            } else {
+                open_orders_pks.push(mango_account.spot_open_orders[x]);
+            }
+        }
+
+        let (dex_signer_pk, _dex_signer_nonce) =
+            create_signer_key_and_nonce(&serum_program_id, &spot_market_cookie.market);
+
+        let instructions = [mango::instruction::edit_spot_order(
+            &mango_program_id,
+            &mango_group_pk,
+            &mango_account_pk,
+            &user.pubkey(),
+            &mango_group.mango_cache,
+            &serum_program_id,
+            &spot_market_cookie.market,
+            &spot_market_cookie.bids,
+            &spot_market_cookie.asks,
+            &spot_market_cookie.req_q,
+            &spot_market_cookie.event_q,
+            &spot_market_cookie.coin_vault,
+            &spot_market_cookie.pc_vault,
+            &mint_root_bank_pk,
+            &mint_node_bank_pk,
+            &mint_node_bank.vault,
+            &quote_root_bank_pk,
+            &quote_node_bank_pk,
+            &quote_node_bank.vault,
+            &signer_pk,
+            &dex_signer_pk,
+            &mango_group.msrm_vault,
+            &open_orders_pks, // oo ais
+            mint_index,
+            cancel_order,
+            new_order,
+        )
+        .unwrap()];
+
+        let signers = vec![&user];
+
+        self.process_transaction(&instructions, Some(&signers)).await.unwrap();
     }
 }
 

--- a/program/tests/program_test/mod.rs
+++ b/program/tests/program_test/mod.rs
@@ -3,7 +3,10 @@ use std::mem::size_of;
 
 use bincode::deserialize;
 use fixed::types::I80F48;
-use serum_dex::{instruction::{CancelOrderInstructionV2, NewOrderInstructionV3}, state::OpenOrders};
+use serum_dex::{
+    instruction::{CancelOrderInstructionV2, NewOrderInstructionV3},
+    state::OpenOrders,
+};
 use solana_program::entrypoint::ProgramResult;
 use solana_program::{
     account_info::AccountInfo,
@@ -1971,13 +1974,14 @@ impl MangoProgramTest {
             self.load_account::<MangoAccount>(liqor_mango_account_pk).await;
     }
 
-#[allow(dead_code)]
+    #[allow(dead_code)]
     pub async fn edit_spot_order(
         &mut self,
         mango_group_cookie: &MangoGroupCookie,
         spot_market_cookie: &SpotMarketCookie,
         user_index: usize,
         cancel_order: CancelOrderInstructionV2,
+        cancel_order_size: u64,
         new_order: NewOrderInstructionV3,
     ) {
         let mango_program_id = self.mango_program_id;
@@ -2050,6 +2054,7 @@ impl MangoProgramTest {
             &open_orders_pks, // oo ais
             mint_index,
             cancel_order,
+            cancel_order_size,
             new_order,
         )
         .unwrap()];

--- a/program/tests/program_test/scenarios.rs
+++ b/program/tests/program_test/scenarios.rs
@@ -202,13 +202,23 @@ pub async fn edit_spot_order_scenario(
     mango_group_cookie: &mut MangoGroupCookie,
     spot_order: &(usize, usize, serum_dex::matching::Side, f64, f64),
     cancel_order_id: u128,
+    cancel_order_size: u64,
 ) {
     mango_group_cookie.run_keeper(test).await;
 
     let (user_index, market_index, order_side, order_size, order_price) = *spot_order;
     let mut spot_market_cookie = mango_group_cookie.spot_markets[market_index];
     spot_market_cookie
-        .edit_order(test, mango_group_cookie, user_index, order_side, order_size, order_price, cancel_order_id)
+        .edit_order(
+            test,
+            mango_group_cookie,
+            user_index,
+            order_side,
+            order_size,
+            order_price,
+            cancel_order_id,
+            cancel_order_size,
+        )
         .await;
 
     mango_group_cookie.users_with_spot_event[market_index].push(user_index);

--- a/program/tests/program_test/scenarios.rs
+++ b/program/tests/program_test/scenarios.rs
@@ -225,7 +225,7 @@ pub async fn edit_spot_order_scenario(
 }
 
 #[allow(dead_code)]
-pub async fn edit_perp_order_scenario(
+pub async fn edit_perp_order_by_client_id_scenario(
     test: &mut MangoProgramTest,
     mango_group_cookie: &mut MangoGroupCookie,
     perp_orders: &Vec<(usize, usize, mango::matching::Side, f64, f64)>,
@@ -238,7 +238,7 @@ pub async fn edit_perp_order_scenario(
         let (user_index, market_index, order_side, order_size, order_price) = *perp_order;
         let mut perp_market_cookie = mango_group_cookie.perp_markets[market_index];
         perp_market_cookie
-            .edit_order(
+            .edit_order_by_client_id(
                 test,
                 mango_group_cookie,
                 user_index,
@@ -247,6 +247,38 @@ pub async fn edit_perp_order_scenario(
                 order_price,
                 PlacePerpOptions::default(),
                 client_order_id,
+                cancel_order_size,
+                false,
+            )
+            .await;
+
+        mango_group_cookie.users_with_perp_event[market_index].push(user_index);
+    }
+}
+
+#[allow(dead_code)]
+pub async fn edit_perp_order_scenario(
+    test: &mut MangoProgramTest,
+    mango_group_cookie: &mut MangoGroupCookie,
+    perp_orders: &Vec<(usize, usize, mango::matching::Side, f64, f64)>,
+    cancel_order_id: i128,
+    cancel_order_size: f64,
+) {
+    mango_group_cookie.run_keeper(test).await;
+
+    for perp_order in perp_orders {
+        let (user_index, market_index, order_side, order_size, order_price) = *perp_order;
+        let mut perp_market_cookie = mango_group_cookie.perp_markets[market_index];
+        perp_market_cookie
+            .edit_order(
+                test,
+                mango_group_cookie,
+                user_index,
+                cancel_order_id,
+                order_side,
+                order_size,
+                order_price,
+                PlacePerpOptions::default(),
                 cancel_order_size,
                 false,
             )

--- a/program/tests/program_test/scenarios.rs
+++ b/program/tests/program_test/scenarios.rs
@@ -223,3 +223,35 @@ pub async fn edit_spot_order_scenario(
 
     mango_group_cookie.users_with_spot_event[market_index].push(user_index);
 }
+
+#[allow(dead_code)]
+pub async fn edit_perp_order_scenario(
+    test: &mut MangoProgramTest,
+    mango_group_cookie: &mut MangoGroupCookie,
+    perp_orders: &Vec<(usize, usize, mango::matching::Side, f64, f64)>,
+    client_order_id: u64,
+    cancel_order_size: f64,
+) {
+    mango_group_cookie.run_keeper(test).await;
+
+    for perp_order in perp_orders {
+        let (user_index, market_index, order_side, order_size, order_price) = *perp_order;
+        let mut perp_market_cookie = mango_group_cookie.perp_markets[market_index];
+        perp_market_cookie
+            .edit_order(
+                test,
+                mango_group_cookie,
+                user_index,
+                order_side,
+                order_size,
+                order_price,
+                PlacePerpOptions::default(),
+                client_order_id,
+                cancel_order_size,
+                false,
+            )
+            .await;
+
+        mango_group_cookie.users_with_perp_event[market_index].push(user_index);
+    }
+}

--- a/program/tests/program_test/scenarios.rs
+++ b/program/tests/program_test/scenarios.rs
@@ -195,3 +195,21 @@ pub async fn match_perp_order_scenario(
     }
     mango_group_cookie.run_keeper(test).await;
 }
+
+#[allow(dead_code)]
+pub async fn edit_spot_order_scenario(
+    test: &mut MangoProgramTest,
+    mango_group_cookie: &mut MangoGroupCookie,
+    spot_order: &(usize, usize, serum_dex::matching::Side, f64, f64),
+    cancel_order_id: u128,
+) {
+    mango_group_cookie.run_keeper(test).await;
+
+    let (user_index, market_index, order_side, order_size, order_price) = *spot_order;
+    let mut spot_market_cookie = mango_group_cookie.spot_markets[market_index];
+    spot_market_cookie
+        .edit_order(test, mango_group_cookie, user_index, order_side, order_size, order_price, cancel_order_id)
+        .await;
+
+    mango_group_cookie.users_with_spot_event[market_index].push(user_index);
+}

--- a/program/tests/test_perp_markets.rs
+++ b/program/tests/test_perp_markets.rs
@@ -582,3 +582,159 @@ async fn test_perp_order_types() {
         );
     }
 }
+
+#[tokio::test]
+async fn test_edit_perp_order() {
+    // === Arrange ===
+    let config = MangoProgramTestConfig::default_two_mints();
+    let mut test = MangoProgramTest::start_new(&config).await;
+
+    let mut mango_group_cookie = MangoGroupCookie::default(&mut test).await;
+    mango_group_cookie.full_setup(&mut test, config.num_users, config.num_mints - 1).await;
+
+    // General parameters
+    let user_index: usize = 0;
+    let mint_index: usize = 0;
+    let base_price: f64 = 10_000.0;
+    let base_size: f64 = 1.0;
+    let mint = test.mints[mint_index];
+
+    // Set oracles
+    mango_group_cookie.set_oracle(&mut test, mint_index, base_price).await;
+
+    // Deposit amounts
+    let user_deposits = vec![
+        (user_index, test.quote_index, base_price * base_size),
+        (user_index, mint_index, base_size),
+    ];
+
+    // Perp Orders
+    let user_perp_orders = vec![(user_index, mint_index, Side::Bid, 1.0, base_price)];
+
+    // === Act ===
+    // Step 1: Make deposits
+    deposit_scenario(&mut test, &mut mango_group_cookie, &user_deposits).await;
+
+    // Step 2: Place perp orders
+    place_perp_order_scenario(&mut test, &mut mango_group_cookie, &user_perp_orders).await;
+
+    // === Assert ===
+    mango_group_cookie.run_keeper(&mut test).await;
+    assert_open_perp_orders(&mango_group_cookie, &user_perp_orders, STARTING_PERP_ORDER_ID);
+
+    let perp_market_cookie = mango_group_cookie.perp_markets[mint_index];
+    let bids = test.load_account::<BookSide>(perp_market_cookie.bids_pk).await;
+    let top_order = bids.get_max().unwrap();
+    assert_eq!(top_order.price(), test.price_number_to_lots(&mint, base_price) as i64);
+    assert_eq!(top_order.quantity, test.base_size_number_to_lots(&mint, base_size) as i64);
+
+    // Step 3: Edit the order
+
+    let updated_perp_orders = vec![(user_index, mint_index, Side::Bid, 1.0, base_price * 0.5)];
+
+    edit_perp_order_scenario(
+        &mut test,
+        &mut mango_group_cookie,
+        &updated_perp_orders,
+        STARTING_PERP_ORDER_ID,
+        base_size,
+    )
+    .await;
+
+    // === Assert ===
+    mango_group_cookie.run_keeper(&mut test).await;
+    assert_open_perp_orders(&mango_group_cookie, &updated_perp_orders, STARTING_PERP_ORDER_ID);
+
+    let updated_bids = test.load_account::<BookSide>(perp_market_cookie.bids_pk).await;
+    let updated_top_order = updated_bids.get_max().unwrap();
+    assert_eq!(
+        updated_top_order.price(),
+        test.price_number_to_lots(&mint, base_price * 0.5) as i64
+    );
+    assert_eq!(updated_top_order.quantity, test.base_size_number_to_lots(&mint, base_size) as i64);
+}
+
+#[tokio::test]
+async fn test_edit_perp_order_will_adjust_order_size_if_user_passes_stale_order() {
+    // === Arrange ===
+    let config = MangoProgramTestConfig::default_two_mints();
+    let mut test = MangoProgramTest::start_new(&config).await;
+
+    let mut mango_group_cookie = MangoGroupCookie::default(&mut test).await;
+    mango_group_cookie.full_setup(&mut test, config.num_users, config.num_mints - 1).await;
+
+    // General parameters
+    let bidder_user_index: usize = 0;
+    let asker_user_index: usize = 1;
+    let mint_index: usize = 0;
+    let base_price: f64 = 10_000.0;
+    let base_size: f64 = 1.0;
+    let mint = test.mints[mint_index];
+
+    // Set oracles
+    mango_group_cookie.set_oracle(&mut test, mint_index, base_price).await;
+
+    // Deposit amounts
+    let user_deposits = vec![
+        (bidder_user_index, test.quote_index, base_price),
+        (asker_user_index, mint_index, 1.0),
+    ];
+
+    // Matched Perp Orders
+    let matched_perp_orders = vec![vec![
+        (asker_user_index, mint_index, mango::matching::Side::Ask, base_size * 0.5, base_price),
+        (bidder_user_index, mint_index, mango::matching::Side::Bid, base_size, base_price),
+    ]];
+
+    // === Act ===
+    // Step 1: Make deposits
+    deposit_scenario(&mut test, &mut mango_group_cookie, &user_deposits).await;
+
+    // Step 2: Place and match spot order
+    match_perp_order_scenario(&mut test, &mut mango_group_cookie, &matched_perp_orders).await;
+
+    // Step 3: Settle pnl
+    mango_group_cookie.run_keeper(&mut test).await;
+    for matched_perp_order in matched_perp_orders {
+        mango_group_cookie.settle_perp_funds(&mut test, &matched_perp_order).await;
+    }
+
+    // === Assert ===
+    mango_group_cookie.run_keeper(&mut test).await;
+
+    // assert_matched_perp_orders(&mango_group_cookie, &user_perp_orders);
+
+    let perp_market_cookie = mango_group_cookie.perp_markets[mint_index];
+    let bids = test.load_account::<BookSide>(perp_market_cookie.bids_pk).await;
+    let top_order = bids.get_max().unwrap();
+    assert_eq!(top_order.price(), test.price_number_to_lots(&mint, base_price) as i64);
+    assert_eq!(top_order.quantity, test.base_size_number_to_lots(&mint, base_size * 0.5) as i64);
+
+    // Step 4: Edit the order
+    let updated_perp_orders =
+        vec![(bidder_user_index, mint_index, Side::Bid, 1.0, base_price * 0.5)];
+
+    edit_perp_order_scenario(
+        &mut test,
+        &mut mango_group_cookie,
+        &updated_perp_orders,
+        STARTING_PERP_ORDER_ID + 1,
+        base_size, // client expects to cancel all of the original order
+    )
+    .await;
+
+    // === Assert ===
+    mango_group_cookie.run_keeper(&mut test).await;
+    assert_open_perp_orders(&mango_group_cookie, &updated_perp_orders, STARTING_PERP_ORDER_ID + 1);
+
+    let updated_bids = test.load_account::<BookSide>(perp_market_cookie.bids_pk).await;
+    let updated_top_order = updated_bids.get_max().unwrap();
+    assert_eq!(
+        updated_top_order.price(),
+        test.price_number_to_lots(&mint, base_price * 0.5) as i64
+    );
+    assert_eq!(
+        updated_top_order.quantity,
+        test.base_size_number_to_lots(&mint, base_size * 0.5) as i64
+    );
+}

--- a/program/tests/test_perp_markets.rs
+++ b/program/tests/test_perp_markets.rs
@@ -584,7 +584,7 @@ async fn test_perp_order_types() {
 }
 
 #[tokio::test]
-async fn test_edit_perp_order() {
+async fn test_edit_perp_order_by_client_id() {
     // === Arrange ===
     let config = MangoProgramTestConfig::default_two_mints();
     let mut test = MangoProgramTest::start_new(&config).await;
@@ -632,7 +632,7 @@ async fn test_edit_perp_order() {
 
     let updated_perp_orders = vec![(user_index, mint_index, Side::Bid, 1.0, base_price * 0.5)];
 
-    edit_perp_order_scenario(
+    edit_perp_order_by_client_id_scenario(
         &mut test,
         &mut mango_group_cookie,
         &updated_perp_orders,
@@ -644,6 +644,163 @@ async fn test_edit_perp_order() {
     // === Assert ===
     mango_group_cookie.run_keeper(&mut test).await;
     assert_open_perp_orders(&mango_group_cookie, &updated_perp_orders, STARTING_PERP_ORDER_ID);
+
+    let updated_bids = test.load_account::<BookSide>(perp_market_cookie.bids_pk).await;
+    let updated_top_order = updated_bids.get_max().unwrap();
+    assert_eq!(
+        updated_top_order.price(),
+        test.price_number_to_lots(&mint, base_price * 0.5) as i64
+    );
+    assert_eq!(updated_top_order.quantity, test.base_size_number_to_lots(&mint, base_size) as i64);
+}
+
+#[tokio::test]
+async fn test_edit_perp_order_by_client_id_will_adjust_order_size_if_user_passes_stale_order() {
+    // === Arrange ===
+    let config = MangoProgramTestConfig::default_two_mints();
+    let mut test = MangoProgramTest::start_new(&config).await;
+
+    let mut mango_group_cookie = MangoGroupCookie::default(&mut test).await;
+    mango_group_cookie.full_setup(&mut test, config.num_users, config.num_mints - 1).await;
+
+    // General parameters
+    let bidder_user_index: usize = 0;
+    let asker_user_index: usize = 1;
+    let mint_index: usize = 0;
+    let base_price: f64 = 10_000.0;
+    let base_size: f64 = 1.0;
+    let mint = test.mints[mint_index];
+
+    // Set oracles
+    mango_group_cookie.set_oracle(&mut test, mint_index, base_price).await;
+
+    // Deposit amounts
+    let user_deposits = vec![
+        (bidder_user_index, test.quote_index, base_price),
+        (asker_user_index, mint_index, 1.0),
+    ];
+
+    // Matched Perp Orders
+    let matched_perp_orders = vec![vec![
+        (asker_user_index, mint_index, mango::matching::Side::Ask, base_size * 0.5, base_price),
+        (bidder_user_index, mint_index, mango::matching::Side::Bid, base_size, base_price),
+    ]];
+
+    // === Act ===
+    // Step 1: Make deposits
+    deposit_scenario(&mut test, &mut mango_group_cookie, &user_deposits).await;
+
+    // Step 2: Place and match spot order
+    match_perp_order_scenario(&mut test, &mut mango_group_cookie, &matched_perp_orders).await;
+
+    // Step 3: Settle pnl
+    mango_group_cookie.run_keeper(&mut test).await;
+    for matched_perp_order in matched_perp_orders {
+        mango_group_cookie.settle_perp_funds(&mut test, &matched_perp_order).await;
+    }
+
+    // === Assert ===
+    mango_group_cookie.run_keeper(&mut test).await;
+
+    // assert_matched_perp_orders(&mango_group_cookie, &user_perp_orders);
+
+    let perp_market_cookie = mango_group_cookie.perp_markets[mint_index];
+    let bids = test.load_account::<BookSide>(perp_market_cookie.bids_pk).await;
+    let top_order = bids.get_max().unwrap();
+    assert_eq!(top_order.price(), test.price_number_to_lots(&mint, base_price) as i64);
+    assert_eq!(top_order.quantity, test.base_size_number_to_lots(&mint, base_size * 0.5) as i64);
+
+    // Step 4: Edit the order
+    let updated_perp_orders =
+        vec![(bidder_user_index, mint_index, Side::Bid, 1.0, base_price * 0.5)];
+
+    edit_perp_order_by_client_id_scenario(
+        &mut test,
+        &mut mango_group_cookie,
+        &updated_perp_orders,
+        STARTING_PERP_ORDER_ID + 1,
+        base_size, // client expects to cancel all of the original order
+    )
+    .await;
+
+    // === Assert ===
+    mango_group_cookie.run_keeper(&mut test).await;
+    assert_open_perp_orders(&mango_group_cookie, &updated_perp_orders, STARTING_PERP_ORDER_ID + 1);
+
+    let updated_bids = test.load_account::<BookSide>(perp_market_cookie.bids_pk).await;
+    let updated_top_order = updated_bids.get_max().unwrap();
+    assert_eq!(
+        updated_top_order.price(),
+        test.price_number_to_lots(&mint, base_price * 0.5) as i64
+    );
+    assert_eq!(
+        updated_top_order.quantity,
+        test.base_size_number_to_lots(&mint, base_size * 0.5) as i64
+    );
+}
+
+#[tokio::test]
+async fn test_edit_perp_order() {
+    // === Arrange ===
+    let config = MangoProgramTestConfig::default_two_mints();
+    let mut test = MangoProgramTest::start_new(&config).await;
+
+    let mut mango_group_cookie = MangoGroupCookie::default(&mut test).await;
+    mango_group_cookie.full_setup(&mut test, config.num_users, config.num_mints - 1).await;
+
+    // General parameters
+    let user_index: usize = 0;
+    let mint_index: usize = 0;
+    let base_price: f64 = 10_000.0;
+    let base_size: f64 = 1.0;
+    let mint = test.mints[mint_index];
+
+    // Set oracles
+    mango_group_cookie.set_oracle(&mut test, mint_index, base_price).await;
+
+    // Deposit amounts
+    let user_deposits = vec![
+        (user_index, test.quote_index, base_price * base_size),
+        (user_index, mint_index, base_size),
+    ];
+
+    // Perp Orders
+    let user_perp_orders = vec![(user_index, mint_index, Side::Bid, 1.0, base_price)];
+
+    // === Act ===
+    // Step 1: Make deposits
+    deposit_scenario(&mut test, &mut mango_group_cookie, &user_deposits).await;
+
+    // Step 2: Place perp orders
+    place_perp_order_scenario(&mut test, &mut mango_group_cookie, &user_perp_orders).await;
+
+    // === Assert ===
+    mango_group_cookie.run_keeper(&mut test).await;
+    assert_open_perp_orders(&mango_group_cookie, &user_perp_orders, STARTING_PERP_ORDER_ID);
+
+    let perp_market_cookie = mango_group_cookie.perp_markets[mint_index];
+    let bids = test.load_account::<BookSide>(perp_market_cookie.bids_pk).await;
+    let top_order = bids.get_max().unwrap();
+    let cancel_order_id = top_order.key;
+    assert_eq!(top_order.price(), test.price_number_to_lots(&mint, base_price) as i64);
+    assert_eq!(top_order.quantity, test.base_size_number_to_lots(&mint, base_size) as i64);
+
+    // Step 3: Edit the order
+
+    let updated_perp_orders = vec![(user_index, mint_index, Side::Bid, 1.0, base_price * 0.5)];
+
+    edit_perp_order_scenario(
+        &mut test,
+        &mut mango_group_cookie,
+        &updated_perp_orders,
+        cancel_order_id,
+        base_size,
+    )
+    .await;
+
+    // === Assert ===
+    mango_group_cookie.run_keeper(&mut test).await;
+    assert_open_perp_orders(&mango_group_cookie, &updated_perp_orders, STARTING_PERP_ORDER_ID + 1);
 
     let updated_bids = test.load_account::<BookSide>(perp_market_cookie.bids_pk).await;
     let updated_top_order = updated_bids.get_max().unwrap();
@@ -707,6 +864,7 @@ async fn test_edit_perp_order_will_adjust_order_size_if_user_passes_stale_order(
     let perp_market_cookie = mango_group_cookie.perp_markets[mint_index];
     let bids = test.load_account::<BookSide>(perp_market_cookie.bids_pk).await;
     let top_order = bids.get_max().unwrap();
+    let cancel_order_id = top_order.key;
     assert_eq!(top_order.price(), test.price_number_to_lots(&mint, base_price) as i64);
     assert_eq!(top_order.quantity, test.base_size_number_to_lots(&mint, base_size * 0.5) as i64);
 
@@ -718,14 +876,14 @@ async fn test_edit_perp_order_will_adjust_order_size_if_user_passes_stale_order(
         &mut test,
         &mut mango_group_cookie,
         &updated_perp_orders,
-        STARTING_PERP_ORDER_ID + 1,
+        cancel_order_id,
         base_size, // client expects to cancel all of the original order
     )
     .await;
 
     // === Assert ===
     mango_group_cookie.run_keeper(&mut test).await;
-    assert_open_perp_orders(&mango_group_cookie, &updated_perp_orders, STARTING_PERP_ORDER_ID + 1);
+    assert_open_perp_orders(&mango_group_cookie, &updated_perp_orders, STARTING_PERP_ORDER_ID + 2);
 
     let updated_bids = test.load_account::<BookSide>(perp_market_cookie.bids_pk).await;
     let updated_top_order = updated_bids.get_max().unwrap();

--- a/program/tests/test_spot_markets.rs
+++ b/program/tests/test_spot_markets.rs
@@ -554,20 +554,25 @@ async fn test_edit_spot_order() {
         test.with_mango_account_deposit(&mango_account_pk, test.quote_index).await;
 
     assert_eq!(deposit_base - deposit_base_after_order, 0);
-    assert_eq!(deposit_quote - deposit_quote_after_order, test.to_native(&quote_mint, base_price * base_size));
+    assert_eq!(
+        deposit_quote - deposit_quote_after_order,
+        test.to_native(&quote_mint, base_price * base_size)
+    );
 
     // Step 3: Edit the order
     let oo = test.get_oo(&mango_group_cookie, mint_index, user_index).await;
 
-    let user_spot_order2 = (
-        user_index,
-        mint_index,
-        serum_dex::matching::Side::Bid,
-        base_size,
-        base_price * 0.50,
-    );
+    let user_spot_order2 =
+        (user_index, mint_index, serum_dex::matching::Side::Bid, base_size, base_price * 0.50);
 
-    edit_spot_order_scenario(&mut test, &mut mango_group_cookie, &user_spot_order2, oo.orders[0]).await;
+    edit_spot_order_scenario(
+        &mut test,
+        &mut mango_group_cookie,
+        &user_spot_order2,
+        oo.orders[0],
+        base_size as u64,
+    )
+    .await;
     mango_group_cookie.run_keeper(&mut test).await;
 
     let expected_values_vec: Vec<(usize, usize, HashMap<&str, I80F48>)> = vec![(
@@ -597,7 +602,10 @@ async fn test_edit_spot_order() {
     println!("{}, {}, {}", deposit_quote, deposit_quote_after_edit, deposit_quote_after_order);
 
     assert_eq!(deposit_base - deposit_base_after_edit, 0);
-    assert_eq!(deposit_quote_after_edit - deposit_quote_after_order, test.to_native(&quote_mint, base_price * base_size * 0.50));
+    assert_eq!(
+        deposit_quote_after_edit - deposit_quote_after_order,
+        test.to_native(&quote_mint, base_price * base_size * 0.50)
+    );
 }
 
 // #[tokio::test]

--- a/program/tests/test_spot_markets.rs
+++ b/program/tests/test_spot_markets.rs
@@ -733,7 +733,7 @@ async fn test_edit_spot_order_will_adjust_order_size_if_user_passes_stale_order(
         base_price * 0.50,
     );
     // Use the original order size (the user is not aware they have been filled)
-    let cancel_size = test.base_size_number_to_lots(&mint, base_size); 
+    let cancel_size = test.base_size_number_to_lots(&mint, base_size);
 
     edit_spot_order_scenario(
         &mut test,


### PR DESCRIPTION
Addresses: https://trello.com/c/PsOOKgpu/130-%F0%9F%90%9E-edit-order-race-condition

This PR adds instructions that edit spot and perp order via cancelling and placing. 

To prevent multiple fills, the user sends a `cancel_order_size` which is the size that they expect to cancel. The `cancel_order_size` is compared with the remaining order size on chain and the new order will have its size reduced if the order to be cancelled has been partially filled without knowledge of the user. If the order the user is intending to cancel has been completely filled without the knowledge of the user, the edit instructions will fail.