### PR TITLE
PlacePerpOrder2: Add flag to request relative expiry

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -28,9 +28,6 @@ show_tree = true # Show inverse dependency trees along with advisories (default:
 arch = "x86_64" # Ignore advisories for CPU architectures other than this one
 os = "linux" # Ignore advisories for operating systems other than this one
 
-[packages]
-source = "all" # "all", "public" or "local"
-
 [yanked]
 enabled = false # Warn for yanked crates in Cargo.lock (default: true)
 update_index = true # Auto-update the crates.io index (default: true)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Mango Program Change Log
 
+## unreleased
+1. Add an ExpiryType argument to PlacePerpOrder2
+
 ## v3.4.7
 Deployed: May 14, 2022 at 21:27:20 UTC | Slot: 133,813,868
 1. Fix overflow in SettlePnl

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1,4 +1,4 @@
-use crate::matching::{OrderType, Side};
+use crate::matching::{ExpiryType, OrderType, Side};
 use crate::state::{AssetType, INFO_LEN};
 use crate::state::{TriggerCondition, MAX_PAIRS};
 use arrayref::{array_ref, array_refs};
@@ -1012,9 +1012,15 @@ pub enum MangoInstruction {
 
         /// Timestamp of when order expires
         ///
-        /// Send 0 if you want the order to never expire.
-        /// Timestamps in the past mean the instruction is skipped.
-        /// Timestamps in the future are reduced to now + 255s.
+        /// If expiry_type is Absolute:
+        /// - Send 0 if you want the order to never expire.
+        /// - Timestamps in the past mean the instruction is skipped.
+        /// - Timestamps in the future are reduced to now + 255s.
+        ///
+        /// If expiry_type is Relative:
+        /// - Must be between 1 and 255.
+        /// - The order will expire when the block timestamp has reached or exceeded
+        ///   the current block timestamp plus that number of seconds.
         expiry_timestamp: u64,
 
         side: Side,
@@ -1029,6 +1035,9 @@ pub enum MangoInstruction {
         /// Use this to limit compute used during order matching.
         /// When the limit is reached, processing stops and the instruction succeeds.
         limit: u8,
+
+        /// Can be 0 -> Absolute or 1 -> Relative; see expiry_timestamp
+        expiry_type: ExpiryType,
     },
 
     /// Cancels all the spot orders pending for a mango account
@@ -1531,6 +1540,7 @@ impl MangoInstruction {
                     reduce_only,
                     limit,
                 ) = array_refs![data_arr, 8, 8, 8, 8, 8, 1, 1, 1, 1];
+                let expiry_type_byte = if data.len() > 44 { data[44] } else { 0 };
                 MangoInstruction::PlacePerpOrder2 {
                     price: i64::from_le_bytes(*price),
                     max_base_quantity: i64::from_le_bytes(*max_base_quantity),
@@ -1541,6 +1551,7 @@ impl MangoInstruction {
                     order_type: OrderType::try_from_primitive(order_type[0]).ok()?,
                     reduce_only: reduce_only[0] != 0,
                     limit: u8::from_le_bytes(*limit),
+                    expiry_type: ExpiryType::try_from_primitive(expiry_type_byte).ok()?,
                 }
             }
             65 => {
@@ -1964,6 +1975,7 @@ pub fn place_perp_order2(
     reduce_only: bool,
     expiry_timestamp: Option<u64>, // Send 0 if you want to ignore time in force
     limit: u8,                     // maximum number of FillEvents before terminating
+    expiry_type: ExpiryType,
 ) -> Result<Instruction, ProgramError> {
     let mut accounts = vec![
         AccountMeta::new_readonly(*mango_group_pk, false),
@@ -1989,6 +2001,7 @@ pub fn place_perp_order2(
         reduce_only,
         expiry_timestamp: expiry_timestamp.unwrap_or(0),
         limit,
+        expiry_type,
     };
     let data = instr.pack();
 

--- a/program/src/matching.rs
+++ b/program/src/matching.rs
@@ -335,6 +335,24 @@ pub enum Side {
     Ask = 1,
 }
 
+#[derive(
+    Eq, PartialEq, Copy, Clone, TryFromPrimitive, IntoPrimitive, Debug, Serialize, Deserialize,
+)]
+#[repr(u8)]
+#[serde(into = "u8", try_from = "u8")]
+pub enum ExpiryType {
+    /// Expire at exactly the given block time.
+    ///
+    /// Orders with an expiry in the past are ignored. Expiry more than 255s in the future
+    /// is clamped to 255 seconds.
+    Absolute,
+
+    /// Expire a number of block time seconds in the future.
+    ///
+    /// Must be between 1 and 255.
+    Relative,
+}
+
 pub const MAX_BOOK_NODES: usize = 1024; // NOTE: this cannot be larger than u32::MAX
 
 /// A binary tree on AnyNode::key()

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -37,7 +37,7 @@ use crate::ids::{
     luna_perp_market, luna_pyth_oracle, luna_root_bank, luna_spot_market, msrm_token, srm_token,
 };
 use crate::instruction::MangoInstruction;
-use crate::matching::{Book, BookSide, OrderType, Side};
+use crate::matching::{Book, BookSide, ExpiryType, OrderType, Side};
 use crate::oracle::{determine_oracle_type, OracleType, StubOracle, STUB_MAGIC};
 use crate::queue::{EventQueue, EventType, FillEvent, LiquidateEvent, OutEvent};
 #[cfg(not(feature = "devnet"))]
@@ -2623,6 +2623,7 @@ impl Processor {
         reduce_only: bool,
         expiry_timestamp: u64,
         limit: u8,
+        expiry_type: ExpiryType,
     ) -> MangoResult {
         check!(price > 0, MangoErrorCode::InvalidParam)?;
         check!(max_base_quantity > 0, MangoErrorCode::InvalidParam)?;
@@ -2669,17 +2670,28 @@ impl Processor {
         let open_orders_accounts = load_open_orders_accounts(&open_orders_ais)?;
 
         let now_ts = Clock::get()?.unix_timestamp as u64;
-        let time_in_force = if expiry_timestamp != 0 {
-            // If expiry is far in the future, clamp to 255 seconds
-            let tif = expiry_timestamp.saturating_sub(now_ts).min(255);
-            if tif == 0 {
-                // If expiry is in the past, ignore the order
-                msg!("Order is already expired");
-                return Ok(());
+        let time_in_force = match expiry_type {
+            ExpiryType::Absolute => {
+                if expiry_timestamp != 0 {
+                    // If expiry is far in the future, clamp to 255 seconds
+                    let tif = expiry_timestamp.saturating_sub(now_ts).min(255) as u8;
+                    if tif == 0 {
+                        // If expiry is in the past or now, ignore the order
+                        msg!("Order is already expired");
+                        return Ok(());
+                    }
+                    tif
+                } else {
+                    0 // never expire
+                }
             }
-            tif as u8
-        } else {
-            0 // never expire
+            ExpiryType::Relative => {
+                check!(
+                    expiry_timestamp > 0 && expiry_timestamp <= 255,
+                    MangoErrorCode::InvalidParam
+                )?;
+                expiry_timestamp as u8
+            }
         };
 
         let mut perp_market =
@@ -6812,6 +6824,7 @@ impl Processor {
                 order_type,
                 reduce_only,
                 limit,
+                expiry_type,
             } => {
                 msg!("Mango: PlacePerpOrder2 client_order_id={}", client_order_id);
                 Self::place_perp_order2(
@@ -6826,6 +6839,7 @@ impl Processor {
                     reduce_only,
                     expiry_timestamp,
                     limit,
+                    expiry_type,
                 )
             }
             MangoInstruction::CancelAllSpotOrders { limit } => {

--- a/program/tests/program_test/mod.rs
+++ b/program/tests/program_test/mod.rs
@@ -806,6 +806,7 @@ impl MangoProgramTest {
             reduce_only,
             expiry_timestamp,
             limit,
+            ExpiryType::Absolute,
         )
         .unwrap()];
         self.process_transaction(&instructions, Some(&[&user])).await.unwrap();


### PR DESCRIPTION
This makes it easier to use TIF when the solana cluster clock does not match the actual clock.

It's not a perfect substitute, since relative expiry will be relative to transaction execution and not to transaction sending.