### PR TITLE
Fix remove_oracle market state checks

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -6854,8 +6854,6 @@ impl Processor {
             .ok_or(throw_err!(MangoErrorCode::InvalidAccount))?;
         mango_group.oracles[oracle_index] = Pubkey::default();
 
-        let token_info = &mut mango_group.tokens[oracle_index];
-
         {
             check!(
                 mango_group.spot_markets[oracle_index].spot_market == Pubkey::default(),
@@ -6866,6 +6864,8 @@ impl Processor {
                 MangoErrorCode::InvalidAccountState
             )?;
         }
+
+        let token_info = &mut mango_group.tokens[oracle_index];
 
         // First make sure this oracle is active
         check!(!token_info.oracle_inactive, MangoErrorCode::InvalidAccountState)?;

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -6859,14 +6859,16 @@ impl Processor {
         // First make sure this oracle is active
         check!(!token_info.oracle_inactive, MangoErrorCode::InvalidAccountState)?;
 
-        check!(
-            token_info.spot_market_mode == MarketMode::Inactive,
-            MangoErrorCode::InvalidAccountState
-        )?;
-        check!(
-            token_info.perp_market_mode == MarketMode::Inactive,
-            MangoErrorCode::InvalidAccountState
-        )?;
+        {
+            check!(
+                mango_group.spot_markets[oracle_index].spot_market == Pubkey::default(),
+                MangoErrorCode::InvalidAccountState
+            )?;
+            check!(
+                mango_group.perp_markets[oracle_index].perp_market == Pubkey::default(),
+                MangoErrorCode::InvalidAccountState
+            )?;
+        }
 
         token_info.oracle_inactive = true;
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -6856,9 +6856,6 @@ impl Processor {
 
         let token_info = &mut mango_group.tokens[oracle_index];
 
-        // First make sure this oracle is active
-        check!(!token_info.oracle_inactive, MangoErrorCode::InvalidAccountState)?;
-
         {
             check!(
                 mango_group.spot_markets[oracle_index].spot_market == Pubkey::default(),
@@ -6869,6 +6866,9 @@ impl Processor {
                 MangoErrorCode::InvalidAccountState
             )?;
         }
+
+        // First make sure this oracle is active
+        check!(!token_info.oracle_inactive, MangoErrorCode::InvalidAccountState)?;
 
         token_info.oracle_inactive = true;
 


### PR DESCRIPTION
remove_oracle fails for spot only markets since their market state is always Default. This PR changes the check to look at market pubkey instead, which should be the default if the market has either never been added, or has been removed with remove_spot/perp_market